### PR TITLE
Changed character order in text fixtures such that tests pass in Travis.

### DIFF
--- a/project/export/tests/test_covers.py
+++ b/project/export/tests/test_covers.py
@@ -157,7 +157,7 @@ class UnicodeTest(BaseExportTest):
         response = self.export_image_covers(post_data)
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,い',
+            'Name,Annotation status,Annotation area,い,A',
             'あ.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
         ]
         self.assert_csv_content_equal(

--- a/project/export/tests/test_covers.py
+++ b/project/export/tests/test_covers.py
@@ -158,7 +158,7 @@ class UnicodeTest(BaseExportTest):
 
         expected_lines = [
             'Name,Annotation status,Annotation area,い,A',
-            'あ.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
+            'あ.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,40.000,60.000',
         ]
         self.assert_csv_content_equal(
             response.content.decode('utf-8'), expected_lines)

--- a/project/export/tests/test_labelset.py
+++ b/project/export/tests/test_labelset.py
@@ -86,8 +86,8 @@ class GeneralTest(BaseExportTest, LabelTest):
         # Lines are sorted by short code
         expected_lines = [
             'Label ID,Short Code',
-            '{id_C},C'.format(id_C=self.labels['C'].pk),
             '{id_A},あ'.format(id_A=self.labels['A'].pk),
+            '{id_C},C'.format(id_C=self.labels['C'].pk),
         ]
         self.assert_csv_content_equal(
             response.content.decode('utf-8'), expected_lines)


### PR DESCRIPTION
Seems the problem is related to how the DB or OS sort unicode chars with respect to "normal" chars. This PR changes the text fixtures to accommodate the build environment. More work is needed to fix across environments.