### PR TITLE
crop patch bugfix and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ docs/_templates
 # Compiled Python
 *.pyc
 
+# Jupyter
+*.ipynb
+
 # Redis dumps
 *.rdb
 

--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -587,3 +587,8 @@ LIKELY_TEST_SOURCE_NAMES = ['test', 'sandbox', 'dummy', 'tmp', 'temp', 'check']
 
 # NewsItem categories used in NewsItem app.
 NEWS_ITEM_CATEGORIES = ['ml', 'source', 'image', 'annotation', 'account']
+
+# Label patch settings
+LABELPATCH_NCOLS = 150  # Size of patch (after scaling)
+LABELPATCH_NROWS = 150  # Size of patch (after scaling)
+LABELPATCH_SIZE_FRACTION = 0.2  # Patch covers this proportion of the original image's greater dimension

--- a/project/images/views.py
+++ b/project/images/views.py
@@ -160,9 +160,11 @@ def source_main(request, source_id):
 
     # Images' annotation status
     browse_url_base = reverse('browse_images', args=[source.id])
+
     def image_count_by_status(annotation_status):
         return image_search_kwargs_to_queryset(
             dict(annotation_status=annotation_status), source).count()
+
     def browse_link_filtered_by_status(annotation_status):
         return browse_url_base + '?' + urllib.urlencode(dict(
             image_form_type='search', annotation_status=annotation_status))

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -756,7 +756,7 @@ class BasePermissionTest(ClientTest):
         self.assertIn("permission", response['error'])
 
 
-def create_sample_image(width=200, height=200, cols=10, rows=10):
+def create_sample_image(width=200, height=200, cols=10, rows=10, mode='RGB'):
     """
     Create a test image. The image content is a color grid.
     Optionally specify pixel width/height, and the color grid cols/rows.
@@ -783,7 +783,7 @@ def create_sample_image(width=200, height=200, cols=10, rows=10):
     min_rgb = 0
     max_rgb = 255
 
-    im = PILImage.new('RGB', (width, height))
+    im = PILImage.new(mode, (width, height))
 
     const_color_value = int(round(
         const_color*(max_rgb - min_rgb) + min_rgb
@@ -817,10 +817,12 @@ def create_sample_image(width=200, height=200, cols=10, rows=10):
 
             # The dict's keys should be the literals 0, 1, and 2.
             # We interpret these as R, G, and B respectively.
-            rgb_color = (color_dict[0], color_dict[1], color_dict[2])
-
-            # Write the RGB color to the range of pixels.
-            im.paste(rgb_color, (left_x, upper_y, right_x, lower_y))
+            if mode in ['L', '1', 'P']:
+                # Gray scale, just grab one of the channels.
+                im.paste(color_dict[0], (left_x, upper_y, right_x, lower_y))
+            else:
+                rgb_color = (color_dict[0], color_dict[1], color_dict[2])
+                im.paste(rgb_color, (left_x, upper_y, right_x, lower_y))
 
     return im
 

--- a/project/visualization/tests/test_utils.py
+++ b/project/visualization/tests/test_utils.py
@@ -1,0 +1,50 @@
+from PIL import Image as PILImage
+
+from django.core.files.storage import get_storage_class
+from django.conf import settings
+
+from lib.tests.utils import ClientTest
+from images.models import Point
+from visualization.utils import generate_patch_if_doesnt_exist, get_patch_path
+
+
+class LabelPatchGenerationTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(LabelPatchGenerationTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        labels = cls.create_labels(cls.user, ['label1'], 'group1')
+        cls.labelset = cls.create_labelset(cls.user, cls.source, labels)
+
+    def test_rgb(self):
+        self._test_helper('RGB')
+
+    def test_rgba(self):
+        self._test_helper('RGBA')
+
+    def test_gray(self):
+        self._test_helper('L')
+
+    def _test_helper(self, image_mode):
+        img = self.upload_image(self.user, self.source,
+                                image_options={'mode': image_mode})
+
+        point_id = Point.objects.filter(image=img)[0].id
+
+        # Assert that patches can be generated without problems
+        try:
+            generate_patch_if_doesnt_exist(point_id)
+        except IOError as msg:
+            self.fail("Error occurred during patch generation: {}".format(msg))
+
+        # Then assert the patch was actually generated and that is RGB
+        storage = get_storage_class()()
+        patch = PILImage.open(storage.open(get_patch_path(point_id)))
+        self.assertEqual(patch.size[0], settings.LABELPATCH_NROWS)
+        self.assertEqual(patch.size[1], settings.LABELPATCH_NCOLS)
+        self.assertEqual(patch.mode, 'RGB')
+
+

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -111,19 +111,19 @@ def generate_patch_if_doesnt_exist(point_id):
 
     # Load image and convert to numpy array.
     point = Point.objects.get(pk=point_id)
-    original_image_relative_path = point.image.original_file.name
+    image = point.image
+    original_image_relative_path = image.original_file.name
     original_image_file = storage.open(original_image_relative_path)
 
     # Figure out the patch size to crop, and which to resize to.
-    patch_size = int(max(point.image.original_width,
-                         point.image.original_height)
+    patch_size = int(max(image.original_width, image.original_height)
                      * settings.LABELPATCH_SIZE_FRACTION)
 
-    # Load the image convert to RGB
+    # Load the image convert to RGB.
     im = PILImage.open(original_image_file)
     im = im.convert('RGB')
 
-    # Crop
+    # Crop.
     region = im.crop((
         point.column - patch_size // 2,
         point.row - patch_size // 2,
@@ -131,6 +131,7 @@ def generate_patch_if_doesnt_exist(point_id):
         point.row + patch_size // 2
     ))
 
+    # Resize to the desired size.
     region = region.resize((settings.LABELPATCH_NCOLS,
                             settings.LABELPATCH_NROWS))
 

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -34,7 +34,8 @@ def image_search_kwargs_to_queryset(search_kwargs, source):
             pass
         elif value == '(none)':
             # Get images with an empty value for this field
-            if isinstance(Metadata._meta.get_field(field_name), model_fields.CharField):
+            if isinstance(Metadata._meta.get_field(field_name),
+                          model_fields.CharField):
                 metadata_kwargs['metadata__' + field_name] = ''
             else:
                 metadata_kwargs['metadata__' + field_name] = None
@@ -114,7 +115,8 @@ def generate_patch_if_doesnt_exist(point_id):
     original_image_file = storage.open(original_image_relative_path)
 
     # Figure out the patch size to crop, and which to resize to.
-    patch_size = int(max(point.image.original_width, point.image.original_height)
+    patch_size = int(max(point.image.original_width,
+                         point.image.original_height)
                      * settings.LABELPATCH_SIZE_FRACTION)
 
     # Load the image convert to RGB
@@ -133,8 +135,10 @@ def generate_patch_if_doesnt_exist(point_id):
                             settings.LABELPATCH_NROWS))
 
     # Save the image.
-    # First use Pillow's save() method on an IO stream (so we don't have to create a temporary file).
-    # Then save the image, using the path constructed earlier and the contents of the stream.
+    # First use Pillow's save() method on an IO stream
+    # (so we don't have to create a temporary file).
+    # Then save the image, using the path constructed earlier
+    # and the contents of the stream.
     # This approach should work with both local and remote storage.
     with BytesIO() as stream:
         region.save(stream, 'JPEG')

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 import operator
 import re
+import numpy as np
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class
@@ -88,87 +89,54 @@ def get_patch_path(point_id):
         point_pk=point.pk,
     )
 
+
 def get_patch_url(point_id):
     return get_storage_class()().url(get_patch_path(point_id))
+
 
 def generate_patch_if_doesnt_exist(point_id):
     """
     If this point doesn't have an image patch file yet, then
     generate one.
-    :param point: Point object to generate a patch for
+    :param point_id: Primary key to point object to generate a patch for
     :return: None
     """
+
     # Get the storage class, then get an instance of it.
     storage = get_storage_class()()
+
     # Check if patch exists for the point
     patch_relative_path = get_patch_path(point_id)
     if storage.exists(patch_relative_path):
         return
 
-    # Generate the patch
-
-    # Size of patch (after scaling)
-    PATCH_X = 150
-    PATCH_Y = 150
-    # Patch covers this proportion of the original image's greater dimension
-    REDUCE_SIZE = 1.0/5.0
-
+    # Load image and convert to numpy array.
     point = Point.objects.get(pk=point_id)
     original_image_relative_path = point.image.original_file.name
     original_image_file = storage.open(original_image_relative_path)
-    image = PILImage.open(original_image_file)
 
-    #determine the crop box
-    max_x = point.image.original_width
-    max_y = point.image.original_height
-    #careful; x is the column, y is the row
-    x = point.column
-    y = point.row
+    # Figure out the patch size to crop, and which to resize to.
+    patch_size = int(max(point.image.original_width, point.image.original_height)
+                     * settings.LABELPATCH_SIZE_FRACTION)
 
-    # TODO: The division ops here MIGHT be dangerous for Python 3, because
-    # the default has changed from integer to decimal division
-    patchSize = int(max(max_x,max_y)*REDUCE_SIZE)
-    patchSize = (patchSize/2)*2  #force patch size to be even
-    halfPatchSize = patchSize/2
-    scaledPatchSize = (PATCH_X, PATCH_Y)
+    # Load the image convert to RGB
+    im = PILImage.open(original_image_file)
+    im = im.convert('RGB')
 
-    # If a patch centered on (x,y) would be too far off to the left,
-    # then just take a patch on the left edge of the image.
-    if x - halfPatchSize < 0:
-        left = 0
-        right = patchSize
-    # If too far to the right, take a patch on the right edge
-    elif x + halfPatchSize > max_x:
-        left = max_x - patchSize
-        right = max_x
-    else:
-        left = x - halfPatchSize
-        right = x + halfPatchSize
+    # Crop
+    region = im.crop((
+        point.column - patch_size // 2,
+        point.row - patch_size // 2,
+        point.column + patch_size // 2,
+        point.row + patch_size // 2
+    ))
 
-    # If too far toward the top, take a patch on the top edge
-    if y - halfPatchSize < 0:
-        upper = 0
-        lower = patchSize
-    # If too far toward the bottom, take a patch on the bottom edge
-    elif y + halfPatchSize > max_y:
-        upper = max_y - patchSize
-        lower = max_y
-    else:
-        upper = y - halfPatchSize
-        lower = y + halfPatchSize
-
-    box = (left,upper,right,lower)
-
-    # Crop the image
-    region = image.crop(box)
-    region = region.resize(scaledPatchSize)
+    region = region.resize((settings.LABELPATCH_NCOLS,
+                            settings.LABELPATCH_NROWS))
 
     # Save the image.
-    #
-    # First use Pillow's save() method on an IO stream (so we don't have to
-    # create a temporary file).
-    # Then save the image, using the path constructed earlier and the
-    # contents of the stream.
+    # First use Pillow's save() method on an IO stream (so we don't have to create a temporary file).
+    # Then save the image, using the path constructed earlier and the contents of the stream.
     # This approach should work with both local and remote storage.
     with BytesIO() as stream:
         region.save(stream, 'JPEG')

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 import operator
 import re
-import numpy as np
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class
@@ -35,8 +34,7 @@ def image_search_kwargs_to_queryset(search_kwargs, source):
             pass
         elif value == '(none)':
             # Get images with an empty value for this field
-            if isinstance(
-              Metadata._meta.get_field(field_name), model_fields.CharField):
+            if isinstance(Metadata._meta.get_field(field_name), model_fields.CharField):
                 metadata_kwargs['metadata__' + field_name] = ''
             else:
                 metadata_kwargs['metadata__' + field_name] = None


### PR DESCRIPTION
Fixes https://github.com/beijbom/coralnet/issues/275.

In addition I made a few changes:
- Used snake_case for all variables
- Moved the constants to settings/base.py
- Simplified logic to crop at the center pixel. This means there may be a black area of pixel is on the edge. But I think that is better since the annotated substrate will always be at the center. (See screenshot below)
- Cleaned up code to use less local vars. Mostly a preference thing, but I don't like assigning local variables if they are only used once. E.g. `x = point.column`.

I tried this in my dev. environment and it appears to do the right thing. 

What I don't like about this PR is that there is no new tests. I was considering moving all image manipulation out to a separate method and test those, but I could not find a meaningful way to do so since at this point there are only four calls to PIL. (open, convert, crop, save).


![Screen Shot 2020-01-10 at 2 36 41 PM](https://user-images.githubusercontent.com/1128855/72193465-751f2680-33be-11ea-93f3-65ef5a538db0.png)

