### PR TITLE
Change deploy URLs from plural to singular nouns

### DIFF
--- a/project/vision_backend_api/urls.py
+++ b/project/vision_backend_api/urls.py
@@ -8,8 +8,8 @@ from . import views
 urlpatterns = [
     url(r'^classifiers/(?P<classifier_id>\d+)/deploy/$',
         views.Deploy.as_view(), name='deploy'),
-    url(r'^deploy_statuses/(?P<job_id>\d+)/$',
+    url(r'^deploy_status/(?P<job_id>\d+)/$',
         views.DeployStatus.as_view(), name='deploy_status'),
-    url(r'^deploy_results/(?P<job_id>\d+)/$',
+    url(r'^deploy_result/(?P<job_id>\d+)/$',
         views.DeployResult.as_view(), name='deploy_result'),
 ]


### PR DESCRIPTION
deploy_statuses -> deploy_status
deploy_results -> deploy_result

For issue #281.

Funnily enough, I was already using singular nouns for the Django-facing URL names, so I only had to change the 'public' URLs.