### PR TITLE
Improving label replacement in a source

### DIFF
--- a/project/annotations/utils.py
+++ b/project/annotations/utils.py
@@ -10,7 +10,6 @@ from accounts.utils import get_robot_user, is_robot_user, get_alleviate_user
 from .models import Annotation
 from images.model_utils import PointGen
 from images.models import Image, Point
-from labels.models import Label
 from vision_backend.tasks import submit_classifier
 
 
@@ -56,8 +55,17 @@ def image_annotation_area_is_editable(image):
     )
 
 
-def get_labels_with_annotations_in_source(source):
-    return Label.objects.filter(annotation__source=source).distinct()
+def label_ids_with_confirmed_annotations_in_source(source):
+    """
+    Get an iterable of label IDs which have at least one confirmed annotation
+    in the given source.
+    """
+    robot_user = get_robot_user()
+    confirmed_annotations_in_source = \
+        source.annotation_set.exclude(user=robot_user)
+    values = confirmed_annotations_in_source.values_list(
+        'label_id', flat=True).distinct()
+    return list(values)
 
 
 def get_annotation_user_display(anno):

--- a/project/labels/forms.py
+++ b/project/labels/forms.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
-from annotations.utils import get_labels_with_annotations_in_source
+from annotations.utils import label_ids_with_confirmed_annotations_in_source
 from lib.exceptions import FileProcessError
 from lib.forms import get_one_form_error
 from .models import Label, LabelGroup, LabelSet, LocalLabel
@@ -411,16 +411,15 @@ class LabelSetForm(Form):
                 raise ValidationError(msg, code='bad_label_id')
 
         # Check if any in-use labels are marked for removal
-        label_ids_in_annotations = list(
-            get_labels_with_annotations_in_source(self.source)
-            .values_list('pk', flat=True))
-        for label_id in label_ids_in_annotations:
+        label_ids_in_confirmed_annotations = \
+            label_ids_with_confirmed_annotations_in_source(self.source)
+        for label_id in label_ids_in_confirmed_annotations:
             if label_id not in label_id_list:
                 label = Label.objects.get(pk=label_id)
                 msg = (
                     "The label '{name}' is marked for removal from the"
                     " labelset, but we can't remove it because the source"
-                    " still has annotations with this label."
+                    " still has confirmed annotations with this label."
                     " Either we messed up, or some annotations have"
                     " changed since you reached this page."
                     " If the problem persists,"

--- a/project/labels/static/js/LabelsetAdd.js
+++ b/project/labels/static/js/LabelsetAdd.js
@@ -5,7 +5,7 @@ var LabelsetAdd = (function() {
 
     var initialLabelIdsLookup = null;
     var initialLabelIdsCount = null;
-    var labelIdsInAnnotationsLookup = null;
+    var labelIdsInConfirmedAnnotationsLookup = null;
     var hasClassifier = null;
 
     var $labelsetLabelIdsField = null;
@@ -41,7 +41,7 @@ var LabelsetAdd = (function() {
         return labelId in initialLabelIdsLookup;
     }
     function isInAnnotations(labelId) {
-        return labelId in labelIdsInAnnotationsLookup;
+        return labelId in labelIdsInConfirmedAnnotationsLookup;
     }
 
     function getSelectedIds() {
@@ -102,7 +102,8 @@ var LabelsetAdd = (function() {
     function disableRemoveButton(labelId) {
         var $addButton = get$removeBox(labelId).find('.add-remove-button');
         $addButton.addClass('disabled');
-        $addButton.attr('title', "Label used by annotations, can't remove");
+        $addButton.attr(
+            'title', "Can't remove; label is used in confirmed annotations");
         $addButton.unbind('click');
     }
 
@@ -321,11 +322,11 @@ var LabelsetAdd = (function() {
      * <SingletonClassName>.<methodName>. */
     return {
         init: function(params) {
-            labelIdsInAnnotationsLookup = {};
-            var idsList = params['labelIdsInAnnotations'];
+            labelIdsInConfirmedAnnotationsLookup = {};
+            var idsList = params['labelIdsInConfirmedAnnotations'];
             var i;
             for (i = 0; i < idsList.length; i++) {
-                labelIdsInAnnotationsLookup[idsList[i]] = true;
+                labelIdsInConfirmedAnnotationsLookup[idsList[i]] = true;
             }
 
             $labelsetLabelIdsField = $('#id_label_ids');

--- a/project/labels/templates/labels/labelset_add.html
+++ b/project/labels/templates/labels/labelset_add.html
@@ -105,7 +105,7 @@
   {# Script in the body will run on page load. #}
   <script type="text/javascript">
     LabelsetAdd.init({
-      'labelIdsInAnnotations': {{ label_ids_in_annotations|jsonify }},
+      'labelIdsInConfirmedAnnotations': {{ label_ids_in_confirmed_annotations|jsonify }},
       'hasClassifier': {{ has_classifier|jsonify }}
     });
     LabelNew.init({

--- a/project/labels/views.py
+++ b/project/labels/views.py
@@ -16,7 +16,7 @@ from django.views.decorators.http import require_POST, require_GET
 
 from accounts.utils import get_robot_user
 from annotations.models import Annotation
-from annotations.utils import get_labels_with_annotations_in_source
+from annotations.utils import label_ids_with_confirmed_annotations_in_source
 from images.models import Source
 from images.utils import filter_out_test_sources
 from lib.decorators import source_permission_required, \
@@ -175,15 +175,15 @@ def labelset_add(request, source_id):
         initial_label_ids = initial_label_ids_str.split(',')
     initial_labels = Label.objects.filter(pk__in=initial_label_ids)
 
-    label_ids_in_annotations = list(
-        get_labels_with_annotations_in_source(source)
-        .values_list('pk', flat=True))
+    label_ids_in_confirmed_annotations = \
+        label_ids_with_confirmed_annotations_in_source(source)
 
     return render(request, 'labels/labelset_add.html', {
         'source': source,
         'labelset_form': labelset_form,
         'initial_labels': initial_labels,
-        'label_ids_in_annotations': label_ids_in_annotations,
+        'label_ids_in_confirmed_annotations':
+            label_ids_in_confirmed_annotations,
         'has_classifier': source.classifier_set.exists(),
 
         # Include a new-label form on the page. It'll be submitted to


### PR DESCRIPTION
To address issue #289.

- On the Add/Remove Labels page, allow removing a label from a labelset when the source only has unconfirmed annotations using that label. Previously, removal was not allowed if there were any annotations, even unconfirmed.
- Change the related management command to not only replace annotations, but also remove the old label from the labelset and initiate a source backend-reset.
- While trying out this functionality, I noticed that the Annotation History page would list a labelset-removed label as "(Deleted label)", even if the label still existed on the site. That seemed misleading, so I changed it.
