### PR TITLE
Respect the global source-view permission

### DIFF
--- a/project/images/tests/test_images.py
+++ b/project/images/tests/test_images.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals
+from django.urls import reverse
+
+from lib.tests.utils import BasePermissionTest, ClientTest
+
+
+class PermissionTest(BasePermissionTest):
+
+    def test_image_detail_private_source(self):
+        img = self.upload_image(self.user, self.private_source)
+        url = reverse('image_detail', args=[img.id])
+        self.assertPermissionDenied(url, None)
+        self.assertPermissionDenied(url, self.user_outsider)
+        self.assertPermissionGranted(url, self.user_viewer)
+        self.assertPermissionGranted(url, self.user_editor)
+        self.assertPermissionGranted(url, self.user_admin)
+
+    def test_image_detail_public_source(self):
+        img = self.upload_image(self.user, self.public_source)
+        url = reverse('image_detail', args=[img.id])
+        self.assertPermissionGranted(url, None)
+        self.assertPermissionGranted(url, self.user_outsider)
+        self.assertPermissionGranted(url, self.user_viewer)
+        self.assertPermissionGranted(url, self.user_editor)
+        self.assertPermissionGranted(url, self.user_admin)
+
+    def test_image_detail_edit_private_source(self):
+        img = self.upload_image(self.user, self.private_source)
+        url = reverse('image_detail_edit', args=[img.id])
+        self.assertPermissionDenied(url, None)
+        self.assertPermissionDenied(url, self.user_outsider)
+        self.assertPermissionDenied(url, self.user_viewer)
+        self.assertPermissionGranted(url, self.user_editor)
+        self.assertPermissionGranted(url, self.user_admin)
+
+    def test_image_detail_edit_public_source(self):
+        img = self.upload_image(self.user, self.public_source)
+        url = reverse('image_detail_edit', args=[img.id])
+        self.assertPermissionDenied(url, None)
+        self.assertPermissionDenied(url, self.user_outsider)
+        self.assertPermissionDenied(url, self.user_viewer)
+        self.assertPermissionGranted(url, self.user_editor)
+        self.assertPermissionGranted(url, self.user_admin)
+
+
+class ImageViewTest(ClientTest):
+    """
+    Test the image view/detail page.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super(ImageViewTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+
+        # Create a source
+        cls.source = cls.create_source(cls.user)
+
+        # Upload a small image and a large image
+        cls.small_image = cls.upload_image(
+            cls.user, cls.source, image_options=dict(width=400, height=400))
+        cls.large_image = cls.upload_image(
+            cls.user, cls.source, image_options=dict(width=1600, height=1600))
+
+    def test_view_page_with_small_image(self):
+        url = reverse('image_detail', kwargs={'image_id': self.small_image.id})
+        response = self.client.get(url)
+        self.assertStatusOK(response)
+
+        # Try fetching the page a second time, to make sure thumbnail
+        # generation doesn't go nuts.
+        response = self.client.get(url)
+        self.assertStatusOK(response)
+
+    def test_view_page_with_large_image(self):
+        url = reverse('image_detail', kwargs={'image_id': self.large_image.id})
+        response = self.client.get(url)
+        self.assertStatusOK(response)
+
+        # Try fetching the page a second time, to make sure thumbnail
+        # generation doesn't go nuts.
+        response = self.client.get(url)
+        self.assertStatusOK(response)

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -715,6 +715,20 @@ class BasePermissionTest(ClientTest):
         if deny_message:
             self.assertContains(response, deny_message)
 
+    def assertRedirectsToLogin(self, url, user=None, post_data=None):
+        if user:
+            self.client.force_login(user)
+        else:
+            # Test while logged out
+            self.client.logout()
+        if post_data is not None:
+            response = self.client.post(url, post_data)
+        else:
+            response = self.client.get(url)
+
+        self.assertRedirects(
+            response, reverse(settings.LOGIN_URL)+'?next='+url)
+
     def assertNotFound(self, url, user=None, post_data=None):
         if user:
             self.client.force_login(user)


### PR DESCRIPTION
There are two types of Permission objects in the database: global permissions and object-level permissions. Global perms include the permission to view sources (i.e. view all sources), or the permission to edit labels (i.e. edit all labels). Object-level perms include the permission to view source 17, or edit source 28.

Up to now, we've only been respecting object-level permissions for source access. That is, in order for user A to view a private source B, one of the following must be true:

- There's an object-level Permission object in the database which specifies 'user A has view access to source B'.
- User A is a superuser (basically bypassing all permission checks).

For @qiminchen's work (and maybe for other situations in the future), we were thinking of adding a third possibility:

- There's a global Permission object in the database which specifies 'user A has view access to any source.' (This could be added, for example, using the admin interface at a URL like `/admin/auth/user/3/change/`.)

------------------

I've concluded that this needs an additional check in Source's `visible_to_user()` in order to work. The good news is that it's basically a one-liner. The not-so-good news is that it's a little unintuitive; if you look at the implementation now, it might seem redundant. Details on what's going on:

- The call `has_perm(perm_name)` checks for a global perm. The call `has_perm(perm_name, obj)` checks for an object-level perm.

- The tricky thing is, `has_perm` behaves very literally: it checks the DB to see if that specific Permission object exists. It can't figure out "hey, this user can view all sources, so they must be able to view source 17 too." This contrasts with django-guardian's `get_objects_for_user()` method, which by default does this more 'semantic' permission checking.

Anyway, besides that, I noticed we were lacking permission tests for some source pages, so I added some. I wanted to write more tests before the Python 3 upgrade anyway.