### PR TITLE
More LIKELY_TEST_SOURCE_NAMES

### DIFF
--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -629,7 +629,8 @@ SELENIUM_TIMEOUTS = {
 }
 
 # We filter on sources that contains these strings for map and some exports.
-LIKELY_TEST_SOURCE_NAMES = ['test', 'sandbox', 'dummy', 'tmp', 'temp', 'check']
+LIKELY_TEST_SOURCE_NAMES = ['test', 'sandbox', 'dummy', 'tmp', 'temp', 'check',
+                            'reviewer']
 
 # NewsItem categories used in NewsItem app.
 NEWS_ITEM_CATEGORIES = ['ml', 'source', 'image', 'annotation', 'account']


### PR DESCRIPTION
Mini PR. As I was looking through the spacer exports, I found these sources:
```
[15/03/2020 12:51:54]: Exporting Reviewer 1 Data, id:224. [40(333)] with 579 images...
[15/03/2020 12:56:36]: Exporting Reviewer 2 Data, id:225. [41(333)] with 579 images...
[15/03/2020 13:01:16]: Exporting Reviewer 3 Data, id:226. [42(333)] with 579 images...
[15/03/2020 13:05:56]: Exporting Reviewer 4 Data, id:227. [43(333)] with 579 images...
[15/03/2020 13:10:40]: Exporting Reviewer 5 Data, id:228. [44(333)] with 578 images...
```
They weren't caught by the current `LIKELY_TEST_SOURCE_NAMES` options, so I added one more string. 