### PR TITLE
Finish Python 3 compatibility except in misc. scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.6
 
 services: postgresql

--- a/project/config/settings/dev_stephen.py
+++ b/project/config/settings/dev_stephen.py
@@ -6,7 +6,7 @@ from .base_devserver import *
 # Pick one.
 from .storage_local import *
 # from .storage_s3 import *
-# from .storage_regtests import *
+# from .storage_s3_regtests import *
 
 MAP_IMAGE_COUNT_TIERS = [5, 20, 50]
 

--- a/project/images/management/commands/checkformissingimages.py
+++ b/project/images/management/commands/checkformissingimages.py
@@ -1,4 +1,6 @@
-import csv
+from __future__ import unicode_literals
+from backports import csv
+from io import open
 import os
 import posixpath
 from django.conf import settings
@@ -36,7 +38,7 @@ class Command(BaseCommand):
         csv_filepath = os.path.join(
             settings.SITE_DIR, 'tmp', 'missing_images.csv')
 
-        with open(csv_filepath, 'wb') as f:
+        with open(csv_filepath, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow([
                 "Source name", "Source id", "Image name",

--- a/project/images/model_utils.py
+++ b/project/images/model_utils.py
@@ -6,15 +6,6 @@
 # file, utils.py.
 
 
-def to_ascii_str(entry):
-    if isinstance(entry, unicode):
-        return entry.encode('ascii', 'ignore')
-    elif not isinstance(entry, str):
-        return str(entry)
-    else:
-        return entry
-
-
 class PointGen():
     """
     - Defines types of point generation.

--- a/project/images/models.py
+++ b/project/images/models.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import posixpath
+import six
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -13,7 +14,7 @@ from easy_thumbnails.fields import ThumbnailerImageField
 from guardian.shortcuts import (
     get_objects_for_user, get_users_with_perms, get_perms, assign, remove_perm)
 
-from .model_utils import PointGen, to_ascii_str
+from .model_utils import PointGen
 from accounts.utils import is_robot_user
 from annotations.model_utils import AnnotationAreaUtils
 from labels.models import LabelSet
@@ -443,7 +444,7 @@ class Source(models.Model):
                        'nbr_confirmed_images', 'nbr_images', 'description',
                        'affiliation', 'nbr_valid_robots', 'best_robot_accuracy']
 
-        return {field: to_ascii_str(getattr(self, field)) for
+        return {field: six.text_type(getattr(self, field)) for
                 field in field_names}
 
     def __str__(self):
@@ -549,7 +550,7 @@ class Metadata(models.Model):
             {field_name: field_value}
         Both field name and values are strings.
         """
-        return {field: to_ascii_str(getattr(self, field)) for
+        return {field: six.text_type(getattr(self, field)) for
                 field in self.EDIT_FORM_FIELDS}
 
 

--- a/project/lib/regtest_utils.py
+++ b/project/lib/regtest_utils.py
@@ -4,7 +4,7 @@ import boto
 
 import os.path as osp
 
-from io import BytesIO
+from io import StringIO
 
 from django.core import management
 from django.core.files.base import ContentFile
@@ -236,7 +236,7 @@ class VisionBackendRegressionTest(ClientTest):
 
         self.client.force_login(self.user)
 
-        with BytesIO() as stream:
+        with StringIO() as stream:
             writer = csv.writer(stream)
             writer.writerow(['Name', 'Row', 'Column', 'Label'])
             for ann in anns:

--- a/project/vision_backend/management/commands/utils.py
+++ b/project/vision_backend/management/commands/utils.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+from io import open
+
 from django.utils import timezone
 
 
@@ -5,8 +8,7 @@ def log(message, filename):
     """ logs message to file """
     now = timezone.now()
     dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
-    with open(filename, 'a') as fp:
-        message_with_time = \
-            u"[{}]: {}".format(dt_string, message).encode('utf-8')
+    with open(filename, 'a', encoding='utf-8') as fp:
+        message_with_time = "[{}]: {}".format(dt_string, message)
         print(message_with_time)
         fp.write(message_with_time + '\n')

--- a/project/vision_backend/management/commands/vb_export_spacer_data.py
+++ b/project/vision_backend/management/commands/vb_export_spacer_data.py
@@ -1,5 +1,5 @@
 import json
-import os
+import posixpath
 
 import boto
 from django.conf import settings
@@ -150,8 +150,8 @@ class Command(BaseCommand):
                     self.image_annotations_json(image))
 
                 # Set image source and target keys.
-                source_image_key = os.path.join(settings.AWS_LOCATION,
-                                                image.original_file.name)
+                source_image_key = posixpath.join(settings.AWS_LOCATION,
+                                                  image.original_file.name)
                 source_feature_key = settings.FEATURE_VECTOR_FILE_PATTERN.\
                     format(full_image_path=source_image_key)
                 target_image_key = image_prefix + '.jpg'

--- a/project/vision_backend/management/commands/vb_inspect_extracted_features.py
+++ b/project/vision_backend/management/commands/vb_inspect_extracted_features.py
@@ -1,5 +1,5 @@
 import json
-import os
+import posixpath
 from collections import defaultdict
 
 from django.conf import settings
@@ -62,7 +62,7 @@ class Command(BaseCommand):
                 try:
                     feats = direct_s3_read(
                         settings.FEATURE_VECTOR_FILE_PATTERN.format(
-                            full_image_path=os.path.join(
+                            full_image_path=posixpath.join(
                                 settings.AWS_LOCATION,
                                 image.original_file.name)), 'json')
                     n_pts = Point.objects.filter(image=image).count()

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -2,7 +2,7 @@
 This file contains helper functions to vision_backend.tasks.
 """
 import boto.sqs
-import os
+import posixpath
 import logging
 import json
 
@@ -122,7 +122,7 @@ def _make_dataset(images):
     """
     gtdict = {}
     for img in images:
-        full_image_path = os.path.join(settings.AWS_LOCATION, img.original_file.name)
+        full_image_path = posixpath.join(settings.AWS_LOCATION, img.original_file.name)
         feature_key = settings.FEATURE_VECTOR_FILE_PATTERN.format(full_image_path = full_image_path)
         anns = Annotation.objects.filter(image = img).order_by('point__id').annotate(gt = F('label__id'))
         gtlabels = [int(ann.gt) for ann in anns]

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 import logging
 import json
 
@@ -50,7 +50,7 @@ def submit_features(image_id, force=False):
         rowcols.append([point.row, point.column])
     
     # Setup the job payload.
-    full_image_path = os.path.join(settings.AWS_LOCATION, img.original_file.name)
+    full_image_path = posixpath.join(settings.AWS_LOCATION, img.original_file.name)
     payload = {
         'bucketname': settings.AWS_STORAGE_BUCKET_NAME,
         'imkey': full_image_path,
@@ -218,7 +218,7 @@ def classify_image(image_id):
     
     feats = direct_s3_read(
         settings.FEATURE_VECTOR_FILE_PATTERN.format(
-            full_image_path=os.path.join(settings.AWS_LOCATION,
+            full_image_path=posixpath.join(settings.AWS_LOCATION,
                                          img.original_file.name)), 'json')
 
     # Classify.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -118,7 +118,7 @@ cchardet==2.1.4
 
 # Scientific computing
 # Changelog: https://numpy.org/devdocs/release.html
-numpy==1.11.1
+numpy==1.18.1
 
 # Library for testing; can replace parts of the system under test with
 # mock objects.


### PR DESCRIPTION
I reckon this should finish issues #59 and #185, thus finishing my part of 'Phase 1' of the Beta 2 rollout.

This PR represents the start of changes which aren't safe to merge into production as long as it's still on Python 2 and old spacer. So this PR uses the `beta2-rollout` branch as a base instead of `master`. We can use `beta2-rollout` as a feature branch leading up to the production rollout of Beta 2 (Python 3, pyspacer, etc.).

Changes in this PR:

- Python 3 compatibility for all `vision_backend` tasks and helpers/utils (as far as I tested; see below). There really wasn't much left to change, though.
- Python 3 compatibility for all management commands (as far as I tested). Some of them incidentally maintain Python 2 compatibility, since I found that useful to test what the working behavior should look like.
- A few `os.path` to `posixpath` changes in the above, for Windows compatibility. (All of these cases were S3 paths, so they should be `posixpath`.)
- numpy version bumped to 1.18.1 to match pyspacer. This numpy version is Py3-only.
- Python 2.7 removed from Travis.

I've automatically or manually tested most of the relevant code on my Windows dev machine, running Python 3.6. There's some stuff I actually got working on my machine for the first time, partly due to needing the `posixpath` changes mentioned above, and I think partly because I forgot to run celery-beat (not just the worker) on a previous attempt. No better time to get it working than immediately before obsoletion, right?

Details on what I tested on my machine:

- Tested almost all tasks - normal cases, not 'already done' cases or error cases. The one I couldn't test was `classify_image`.
  - I got stuck on the `predict_proba()` call - got `AttributeError: 'Worker' object has no attribute '_config'`, and couldn't figure out how to solve it. I was running Python 3.6 and scikit-learn 0.17.1, and unpickled the model the same way that pyspacer does. In any case, this just means that if you're keeping any Beta 1 code from `classify_image`, you might have to check that a bit more carefully compared to the other code.
- Tested the deploy API using curl commands.
- Tested all management commands, with the default or most basic parameters. Including regtests (small). Though I couldn't get `vb_classify_images` to actually classify images, since it calls the aforementioned task.

The 'misc. scripts' not covered for Py3 compatibility include: `images/scripts.py`, `vision_backend/scripts.py`, and contents of the `scripts` folder at the repo root. Those can be done later or as needed, as discussed in PR #309.

Miscellaneous notes:

- When testing on my dev machine, in `get_total_messages_in_jobs_queue()`, I had to specify `aws_access_key_id` and `aws_secret_access_key` keyword arguments to connect to boto. Omitting those is only fine in production. However, per https://github.com/beijbom/coralnet-system/issues/11 I thought it would be best to have an if-else case (or similar) where production omits these keys, and machines not living on AWS have to specify the keys. I didn't commit any changes here for now, but just something to keep in mind.

- I looked through the [numpy release notes](https://numpy.org/devdocs/release.html) for things relevant to the coralnet code. There were a few things I didn't 100% confirm if they would be an issue or not, either due to difficulty of Ctrl+F to find usages, or other reasons:

  - 1.14: Truth testing of an empty array is deprecated.
  - 1.15: Multidimensional indexing with anything but a tuple is deprecated.
  - 1.18: `numpy.argmin/argmax/min/max` returns `NaT` if it exists in array. (The only non-test usage of `argmax` ultimately gets its argument from the result of `predict_proba()`, which was the thing I couldn't test.)