### PR TITLE
Allow duplicate points in import + Add management command to detect dupes

### DIFF
--- a/docs/design/annotation.rst
+++ b/docs/design/annotation.rst
@@ -4,6 +4,19 @@ Annotation related design notes
 
 Point columns and rows start from 0, not 1
 ------------------------------------------
-Up until early 2020, point column values ranged from 1 to the image width in pixels, and point rows ranged from 1 to the image height. This decision was either made arbitrarily, or made with a concern of being more intuitive to less-technical users.
+See issue #314. Up until early 2020, point column values ranged from 1 to the image width in pixels, and point rows ranged from 1 to the image height. This decision was either made arbitrarily, or made with a concern of being more intuitive to less-technical users.
 
 However, there were some bounds checks, calculations, etc. across the site which mistakenly assumed the ranges were 0 to width-1 and 0 to height-1, or passed the point locations into 0-indexed coordinate systems (Pillow images, Javascript positioning, etc.) without first converting to 0-indexing. From this, and the fact that spacer was already assuming 0-indexing instead of 1-indexing, we realized it would make life easier to change everything in CoralNet to assume 0-indexing.
+
+
+Points with the same row/column positions in the same image are allowed
+-----------------------------------------------------------------------
+See issue #308 - these 'duplicate points' are allowed because:
+
+- By the time we seriously thought of disallowing them in 2020, we already had quite a few duplicate points in CoralNet - spanning 147 different sources. Any idea for removing/correcting these duplicates seemed risky and/or hacky.
+
+- CPCe allows them.
+
+- Allowing duplicate points is essentially doing sampling with replacement, which is a valid statistical method.
+
+In the future, we may give users the option to disallow duplicate points or not when generating or uploading points. However, to our memory, no one has requested this yet. See issue #316.

--- a/project/images/management/commands/detect_dupe_points.py
+++ b/project/images/management/commands/detect_dupe_points.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals
+from backports import csv
+from io import open
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from tqdm import tqdm
+
+from images.models import Source
+
+
+class Command(BaseCommand):
+    help = "Detect Images which have 2+ Points on the same pixel location."
+
+    def handle(self, *args, **options):
+
+        csv_filepath = os.path.join(
+            settings.SITE_DIR, 'tmp', 'images_with_dupe_points.csv')
+
+        with open(csv_filepath, 'w', newline='', encoding='utf-8') as f:
+
+            fieldnames = [
+                "Source name", "Source id", "Image name",
+                "Image id", "Dupe point count", "Point count",
+                "Point generation", "Annotation area",
+                "Resolution", "Annotation status",
+            ]
+            writer = csv.DictWriter(f, fieldnames)
+            writer.writeheader()
+
+            images_with_dupes_count = 0
+
+            # Splitting loops into sources and images, instead of just
+            # images, seems to avoid a bug where nothing is printed and the
+            # command gets killed after 2 minutes.
+            sources = Source.objects.all()
+
+            for source in tqdm(sources, disable=settings.TQDM_DISABLE):
+
+                for image in source.image_set.all():
+
+                    points = image.point_set
+                    distinct_points = \
+                        points.values_list('column', 'row').distinct()
+
+                    if points.count() != distinct_points.count():
+
+                        output_line = (
+                            '{source_name} (source {source_id})'
+                            ' - image {image_id}'.format(
+                                source_name=source.name,
+                                source_id=source.pk,
+                                image_id=image.pk))
+                        self.stdout.write(output_line)
+
+                        dupe_point_count = \
+                            points.count() - distinct_points.count()
+                        writer.writerow({
+                            "Source name": source.name,
+                            "Source id": source.pk,
+                            "Image name": image.metadata.name,
+                            "Image id": image.pk,
+                            "Dupe point count": dupe_point_count,
+                            "Point count": points.count(),
+                            "Point generation":
+                                image.point_gen_method_display(),
+                            "Annotation area":
+                                image.annotation_area_display(),
+                            "Resolution": "{w} x {h}".format(
+                                w=image.original_width,
+                                h=image.original_height),
+                            "Annotation status":
+                                image.get_annotation_status_str(),
+                        })
+
+                        images_with_dupes_count += 1
+
+        self.stdout.write(
+            "Number of images with duplicate points: {}".format(
+                images_with_dupes_count))
+        self.stdout.write(
+            "Results have been written to {}".format(csv_filepath))

--- a/project/upload/tests/test_annotations.py
+++ b/project/upload/tests/test_annotations.py
@@ -1239,22 +1239,26 @@ class UploadAnnotationsContentsTest(UploadAnnotationsBaseTest):
     def test_multiple_points_same_row_column_csv(self):
         """
         More than one point in the same image on the exact same position
-        (same row and same column) should not be allowed.
+        (same row and same column) should be allowed.
         """
-        self.do_error_csv(
+        self.do_success_csv(
             [(150, 90), (20, 20), (150, 90)],
-            "Image 1.png has multiple points on the same position:"
-            " row 90, column 150")
+            {
+                (150, 90, 1, self.img1.pk),
+                (20, 20, 2, self.img1.pk),
+                (150, 90, 3, self.img1.pk),
+            })
 
     def test_multiple_points_same_row_column_cpc(self):
         # These CPC file values for points 1 and 3
         # are different, but they map to the same pixel.
-        self.do_error_cpc(
+        self.do_success_cpc(
             [(150*15-2, 90*15-2), (20*15, 20*15), (150*15+2, 90*15+2)],
-            "From file 1.cpc:"
-            " Points 1 and 3 are on the same"
-            " pixel position:"
-            " row 90, column 150")
+            {
+                (150, 90, 1, self.img1.pk),
+                (20, 20, 2, self.img1.pk),
+                (150, 90, 3, self.img1.pk),
+            })
 
     def test_label_not_in_labelset_csv(self):
         self.do_error_csv(

--- a/project/upload/utils.py
+++ b/project/upload/utils.py
@@ -280,8 +280,6 @@ def annotations_csv_verify_contents(csv_annotations, source):
             # to upload but are still tracking in their records.
             continue
 
-        row_col_set = set()
-
         for point_number, point_dict in enumerate(annotations_for_image, 1):
 
             # Check that row/column are integers within the image dimensions.
@@ -340,13 +338,6 @@ def annotations_csv_verify_contents(csv_annotations, source):
                         " No label of code {code} found"
                         " in this source's labelset".format(
                             code=label_code))
-
-            if (row, column) in row_col_set:
-                raise FileProcessError(
-                    "Image {name} has multiple points on the same position:"
-                    " row {row}, column {column}".format(
-                        name=image_name, row=row, column=column))
-            row_col_set.add((row, column))
 
         annotations[img.pk] = annotations_for_image
 
@@ -581,7 +572,6 @@ def annotations_cpc_verify_contents(cpc_dicts, source):
             )
         image_names_to_cpc_filenames[image_name] = cpc_filename
 
-        row_col_dict = dict()
         annotations_for_image = []
 
         for point_number, cpc_point_dict in enumerate(cpc_dict['points'], 1):
@@ -652,18 +642,6 @@ def annotations_cpc_verify_contents(cpc_dicts, source):
                         " in this source's labelset".format(
                             code=label_code))
                 point_dict['label'] = label_code
-
-            if (row, column) in row_col_dict:
-                raise FileProcessError(
-                    "From file {cpc_filename}:"
-                    " Points {p1} and {p2} are on the same"
-                    " pixel position:"
-                    " row {row}, column {column}".format(
-                        cpc_filename=cpc_filename,
-                        p1=row_col_dict[(row, column)],
-                        p2=point_number,
-                        row=row, column=column))
-            row_col_dict[(row, column)] = point_number
 
             annotations_for_image.append(point_dict)
 


### PR DESCRIPTION
- Allowed duplicate points in CSV/CPC annotation import, per issue #308. I opted not to display any warning about duplicates, since point generation doesn't do that either.

- Added a management command to detect images with duplicate points, and output details to a CSV.

This is another PR which can be merged into master, followed by another rebase of `beta2-rollout` onto master. There will probably be a few more small PRs like this.