### PR TITLE
CPC annotation upload: detect pixel scale factor

### DIFF
--- a/project/annotations/tests/test_history.py
+++ b/project/annotations/tests/test_history.py
@@ -55,7 +55,8 @@ class AnnotationHistoryTest(ClientTest, UploadAnnotationsTestMixin):
 
         cls.img = cls.upload_image(
             cls.user, cls.source,
-            image_options=dict(filename='1.png'))
+            image_options=dict(filename='1.png', width=100, height=100))
+        cls.image_dimensions = (100, 100)
 
     def view_history(self, user):
         if user:
@@ -240,7 +241,7 @@ class AnnotationHistoryTest(ClientTest, UploadAnnotationsTestMixin):
     def test_cpc_import(self):
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (9*15, 9*15, 'A'),
                     (19*15, 19*15, ''),

--- a/project/export/utils.py
+++ b/project/export/utils.py
@@ -200,7 +200,10 @@ def write_annotations_cpc(cpc_stream, img, cpc_prefs):
     row = [
         u'"' + cpc_prefs[u'local_code_filepath'] + u'"',
         u'"' + str(local_image_path) + u'"',
-        # Image dimensions. CPCe operates in units of 1/15th of a pixel.
+        # Image dimensions. CPCe typically operates in units of 1/15th of a
+        # pixel. If a different DPI setting is used in an older version of CPCe
+        # (like CPCe 3.5), it can be something else like 1/12th. But we'll
+        # assume 1/15th for export.
         img.original_width * 15,
         img.original_height * 15,
         # These 2 items seem to be the display width/height that the image

--- a/project/upload/tests/test_annotations.py
+++ b/project/upload/tests/test_annotations.py
@@ -164,6 +164,8 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
             cls.user, cls.source,
             image_options=dict(filename='3.png', width=200, height=100))
 
+        cls.image_dimensions = (200, 100)
+
         # Get full diff output if something like an assertEqual fails
         cls.maxDiff = None
 
@@ -195,7 +197,7 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
         """
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, ''),
                     (60*15, 40*15, ''),
@@ -203,7 +205,7 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
                     (80*15, 20*15, ''),
                     (90*15, 10*15, '')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (0, 0, ''),
                     (2992, 1492, ''),
@@ -306,12 +308,12 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
         """
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, 'A'),
                     (60*15, 40*15, 'B')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (70*15, 30*15, 'A'),
                     (80*15, 20*15, 'A')]),
@@ -414,17 +416,17 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
         """
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, 'A'),
                     (60*15, 40*15, 'B')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (70*15, 30*15, 'A'),
                     (80*15, 20*15, '')]),
             self.make_cpc_file(
-                '3.cpc',
+                self.image_dimensions, '3.cpc',
                 r"C:\My Photos\2017-05-13 GBR\3.png", [
                     (70*15, 30*15, ''),
                     (80*15, 20*15, '')]),
@@ -548,17 +550,17 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
         """
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, 'A'),
                     (60*15, 40*15, 'B')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (70*15, 30*15, 'A'),
                     (80*15, 20*15, '')]),
             self.make_cpc_file(
-                '3.cpc',
+                self.image_dimensions, '3.cpc',
                 r"C:\My Photos\2017-05-13 GBR\3.png", [
                     (70*15, 30*15, ''),
                     (80*15, 20*15, '')]),
@@ -568,17 +570,17 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
 
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (10*15, 10*15, 'A'),
                     (20*15, 20*15, 'A')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (30*15, 30*15, ''),
                     (40*15, 40*15, '')]),
             self.make_cpc_file(
-                '3.cpc',
+                self.image_dimensions, '3.cpc',
                 r"C:\My Photos\2017-05-13 GBR\3.png", [
                     (50*15, 50*15, 'A'),
                     (60*15, 60*15, 'B')]),
@@ -695,7 +697,7 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
 
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (60*15, 40*15, 'aBc')]),
         ]
@@ -774,11 +776,14 @@ class UploadAnnotationsTest(UploadAnnotationsBaseTest):
         """
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, 'A')]),
+            # image parameter is just for getting image dimensions.
+            # This cpc should be skipped anyway, so we don't care which image
+            # we pass in.
             self.make_cpc_file(
-                '4.cpc',
+                self.image_dimensions, '4.cpc',
                 r"C:\My Photos\2017-05-13 GBR\4.png", [
                     (60*15, 40*15, 'B')]),
         ]
@@ -858,6 +863,8 @@ class UploadAnnotationsMultipleSourcesTest(UploadAnnotationsBaseTest):
             cls.user, cls.source2,
             image_options=dict(filename='2.png', width=100, height=100))
 
+        cls.image_dimensions = (100, 100)
+
     def test_other_sources_unaffected_csv(self):
         """
         We shouldn't touch images of other sources which happen to have
@@ -897,12 +904,12 @@ class UploadAnnotationsMultipleSourcesTest(UploadAnnotationsBaseTest):
         # Upload to source 2
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (10*15, 10*15, 'B'),
                     (20*15, 20*15, 'B')]),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (15*15, 15*15, 'A'),
                     (25*15, 25*15, 'A')]),
@@ -913,12 +920,12 @@ class UploadAnnotationsMultipleSourcesTest(UploadAnnotationsBaseTest):
         # Upload to source 1
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.png", [
                     (50*15, 50*15, 'A')]),
             # This image doesn't exist in source 1
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.png", [
                     (60*15, 40*15, 'B')]),
         ]
@@ -1029,6 +1036,9 @@ class UploadAnnotationsContentsTest(UploadAnnotationsBaseTest):
             cls.user, cls.source,
             image_options=dict(filename='2.png', width=100, height=200))
 
+        cls.image_dimensions_1 = (200, 100)
+        cls.image_dimensions_2 = (100, 200)
+
     def do_success_csv(self, point_data, expected_points_set):
         rows = [['1.png']+list(p) for p in point_data]
         if len(rows[0]) == 3:
@@ -1060,10 +1070,13 @@ class UploadAnnotationsContentsTest(UploadAnnotationsBaseTest):
 
     def do_success_cpc(self, point_data, expected_points_set):
         if len(point_data[0]) == 2:
+            # point_data elements have (column, row). Add a blank label code.
             point_data = [p+('',) for p in point_data]
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png", point_data)]
+                self.image_dimensions_1,
+                '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
+                point_data)]
         self.preview_cpc_annotations(self.user, self.source, cpc_files)
         self.upload_annotations(self.user, self.source)
 
@@ -1077,7 +1090,9 @@ class UploadAnnotationsContentsTest(UploadAnnotationsBaseTest):
             point_data = [p+('',) for p in point_data]
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png", point_data)]
+                self.image_dimensions_1,
+                '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
+                point_data)]
         preview_response = self.preview_cpc_annotations(
             self.user, self.source, cpc_files)
 
@@ -1292,10 +1307,13 @@ class UploadAnnotationsContentsTest(UploadAnnotationsBaseTest):
 
     def test_no_specified_images_found_in_source_cpc(self):
         cpc_files = [
+            # We don't care which image we pass as the first parameter.
             self.make_cpc_file(
+                self.image_dimensions_1,
                 '3.cpc', r"C:\My Photos\2017-05-13 GBR\3.png", [
                     (50*15, 50*15, '')]),
             self.make_cpc_file(
+                self.image_dimensions_1,
                 '4.cpc', r"C:\My Photos\2017-05-13 GBR\4.png", [
                     (60*15, 40*15, '')]),
         ]
@@ -1330,6 +1348,8 @@ class UploadAnnotationsFormatTest(UploadAnnotationsBaseTest):
         cls.imgA = cls.upload_image(
             cls.user, cls.source,
             image_options=dict(filename='あ.png', width=100, height=100))
+
+        cls.image_dimensions = (100, 100)
 
     def check(self, preview_response, upload_response, img, label_code):
 
@@ -1395,6 +1415,7 @@ class UploadAnnotationsFormatTest(UploadAnnotationsBaseTest):
         # Unicode on the label code, not the filepath.
         cpc_files = [
             self.make_cpc_file(
+                self.image_dimensions,
                 '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
                 [(50*15, 50*15, 'い')]),
         ]
@@ -1421,6 +1442,7 @@ class UploadAnnotationsFormatTest(UploadAnnotationsBaseTest):
         """Don't know if CPC with crlf newlines is possible in practice, but
         might as well test that it works."""
         cpc_file_lf = self.make_cpc_file(
+            self.image_dimensions,
             '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
             [(50*15, 50*15, 'A')])
         cpc_file_crlf_content = cpc_file_lf.read().replace('\n', '\r\n')
@@ -1450,6 +1472,7 @@ class UploadAnnotationsFormatTest(UploadAnnotationsBaseTest):
         """Don't know if CPC with cr newlines is possible in practice, but
         might as well test that it works."""
         cpc_file_lf = self.make_cpc_file(
+            self.image_dimensions,
             '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
             [(50*15, 50*15, 'A')])
         cpc_file_crlf_content = cpc_file_lf.read().replace('\n', '\r')
@@ -1479,6 +1502,7 @@ class UploadAnnotationsFormatTest(UploadAnnotationsBaseTest):
         """Don't know if CPC with UTF-8 BOM is possible in practice, but
         might as well test that it works."""
         cpc_file_lf = self.make_cpc_file(
+            self.image_dimensions,
             '1.cpc', r"C:\My Photos\2017-05-13 GBR\1.png",
             [(50*15, 50*15, 'A')])
         cpc_file_crlf_content = (

--- a/project/upload/tests/test_annotations_cpc.py
+++ b/project/upload/tests/test_annotations_cpc.py
@@ -230,14 +230,12 @@ class CPCFormatTest(UploadAnnotationsBaseTest):
     def test_multiple_cpcs_for_one_image(self):
         stream = StringIO()
         # Line 1
-        stream.writelines(['a,"D:\\Panama transects\\1.png",c,d,e,f\n'])
+        stream.writelines(['a,"D:\\Panama transects\\1.png",1500,1500,e,f\n'])
         # Lines 2-5
         stream.writelines(['1,2\n']*4)
         # Line 6
         stream.writelines(['10\n'])
         # Lines 7-16: point positions
-        # Multiply by 15 so they end up on different pixels. Otherwise
-        # we may get the 'multiple points on same pixel' error instead.
         stream.writelines([
             '{n},{n}\n'.format(n=n*15) for n in range(10)])
         # Line 17-26: labels
@@ -246,7 +244,7 @@ class CPCFormatTest(UploadAnnotationsBaseTest):
 
         stream = StringIO()
         # Line 1
-        stream.writelines(['a,"D:\\GBR transects\\1.png",c,d,e,f\n'])
+        stream.writelines(['a,"D:\\GBR transects\\1.png",1500,1500,e,f\n'])
         # Lines 2-5
         stream.writelines(['1,2\n']*4)
         # Line 6
@@ -269,6 +267,122 @@ class CPCFormatTest(UploadAnnotationsBaseTest):
                 " per image.")))
 
 
+class CPCPixelScaleFactorTest(UploadAnnotationsBaseTest):
+    """
+    Tests CPC pixel scale factor detection, based on line 1 of the CPC.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super(CPCPixelScaleFactorTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        labels = cls.create_labels(cls.user, ['A', 'B'], 'Group1')
+        cls.create_labelset(cls.user, cls.source, labels)
+
+        cls.img1 = cls.upload_image(
+            cls.user, cls.source,
+            image_options=dict(filename='1.png', width=100, height=200))
+
+    def preview(self, line_1, point_positions=None):
+        """
+        line_1 should be the content of the .cpc file's first line.
+
+        point_positions should be a list of (col, row) tuples, in CPCe-scale
+        units.
+
+        This method writes valid content for the rest of the .cpc file,
+        and then calls the preview view.
+        """
+        if point_positions is None:
+            point_positions = [(0, 0)]
+
+        stream = StringIO()
+        # Line 1
+        stream.writelines(['{}\n'.format(line_1)])
+        # Lines 2-5
+        stream.writelines(['1,2\n']*4)
+        # Line 6
+        stream.writelines(['{}\n'.format(len(point_positions))])
+        # Point positions
+        stream.writelines(
+            ['{},{}\n'.format(pos[0], pos[1]) for pos in point_positions])
+        # Labels
+        stream.writelines(['"","A","",""\n' for _ in point_positions])
+
+        cpc_file = ContentFile(stream.getvalue(), name='1.cpc')
+        # Return the preview response
+        return self.preview_cpc_annotations(
+            self.user, self.source, [cpc_file])
+
+    def test_width_not_integer(self):
+        preview_response = self.preview(line_1='a,1.png,c,3000,e,f')
+
+        self.assertDictEqual(
+            preview_response.json(),
+            dict(error=(
+                "File 1.cpc: The image width and height on line 1"
+                " must be integers.")))
+
+    def test_height_not_integer(self):
+        preview_response = self.preview(line_1='a,1.png,1500,3000.0,e,f')
+
+        self.assertDictEqual(
+            preview_response.json(),
+            dict(error=(
+                "File 1.cpc: The image width and height on line 1"
+                " must be integers.")))
+
+    def test_x_scale_not_integer(self):
+        preview_response = self.preview(line_1='a,1.png,1050,2100,e,f')
+
+        self.assertDictEqual(
+            preview_response.json(),
+            dict(error=(
+                "File 1.cpc: Could not establish an integer scale"
+                " factor from line 1.")))
+
+    def test_y_scale_not_integer(self):
+        preview_response = self.preview(line_1='a,1.png,1500,2999,e,f')
+
+        self.assertDictEqual(
+            preview_response.json(),
+            dict(error=(
+                "File 1.cpc: Could not establish an integer scale"
+                " factor from line 1.")))
+
+    def test_xy_scales_not_equal(self):
+        preview_response = self.preview(line_1='a,1.png,1200,3000,e,f')
+
+        self.assertDictEqual(
+            preview_response.json(),
+            dict(error=(
+                "File 1.cpc: Could not establish an integer scale"
+                " factor from line 1.")))
+
+    def test_scale_of_15(self):
+        """This is the common case and arises from usage at 96 DPI."""
+        self.preview(
+            line_1='a,1.png,1500,3000,e,f', point_positions=[(1200, 900)])
+        self.upload_annotations(self.user, self.source)
+
+        values_set = set(
+            self.img1.point_set.all()
+            .values_list('column', 'row', 'point_number'))
+        self.assertSetEqual(values_set, {(80, 60, 1)})
+
+    def test_scale_of_12(self):
+        """This arises from usage at 120 DPI, and should also be accepted."""
+        self.preview(
+            line_1='a,1.png,1200,2400,e,f', point_positions=[(960, 720)])
+        self.upload_annotations(self.user, self.source)
+
+        values_set = set(
+            self.img1.point_set.all()
+            .values_list('column', 'row', 'point_number'))
+        self.assertSetEqual(values_set, {(80, 60, 1)})
+
+
 class SaveCPCInfoTest(UploadAnnotationsBaseTest):
     """
     Tests for saving of CPC file info when uploading CPCs.
@@ -289,10 +403,12 @@ class SaveCPCInfoTest(UploadAnnotationsBaseTest):
             cls.user, cls.source,
             image_options=dict(filename='2.jpg', width=100, height=100))
 
+        cls.image_dimensions = (100, 100)
+
     def test_cpc_content_one_image(self):
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.jpg", [
                     (49*15, 49*15, 'A'),
                     (59*15, 39*15, 'B')]),
@@ -315,12 +431,12 @@ class SaveCPCInfoTest(UploadAnnotationsBaseTest):
     def test_cpc_content_multiple_images(self):
         cpc_files = [
             self.make_cpc_file(
-                'GBR_1.cpc',
+                self.image_dimensions, 'GBR_1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.jpg", [
                     (49*15, 49*15, 'A'),
                     (59*15, 39*15, 'B')]),
             self.make_cpc_file(
-                'GBR_2.cpc',
+                self.image_dimensions, 'GBR_2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.jpg", [
                     (69*15, 29*15, 'A'),
                     (79*15, 19*15, 'A')]),
@@ -345,13 +461,13 @@ class SaveCPCInfoTest(UploadAnnotationsBaseTest):
     def test_source_fields(self):
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
+                self.image_dimensions, '1.cpc',
                 r"C:\My Photos\2017-05-13 GBR\1.jpg", [
                     (49*15, 49*15, 'A'),
                     (59*15, 39*15, 'B')],
                 codes_filepath=r'C:\PROGRA~4\CPCE_4~1\SHALLO~1.TXT'),
             self.make_cpc_file(
-                '2.cpc',
+                self.image_dimensions, '2.cpc',
                 r"C:\My Photos\2017-05-13 GBR\2.jpg", [
                     (69*15, 29*15, 'A'),
                     (79*15, 19*15, 'A')],
@@ -385,7 +501,8 @@ class CPCImageMatchingTest(UploadAnnotationsBaseTest):
         cls.create_labelset(cls.user, cls.source, labels)
 
     def upload_image_with_name(self, image_name):
-        img = self.upload_image(self.user, self.source)
+        img = self.upload_image(
+            self.user, self.source, image_options=dict(width=100, height=100))
         img.metadata.name = image_name
         img.metadata.save()
         return img
@@ -393,9 +510,10 @@ class CPCImageMatchingTest(UploadAnnotationsBaseTest):
     def upload_preview_for_image_name(self, image_name):
         cpc_files = [
             self.make_cpc_file(
-                '1.cpc',
-                image_name,
-                [(9*15, 9*15, 'A')],
+                dimensions=(100, 100),
+                cpc_filename='1.cpc',
+                image_filepath=image_name,
+                points=[(9*15, 9*15, 'A')],
                 codes_filepath=r'C:\PROGRA~4\CPCE_4~1\SHALLO~1.TXT'),
         ]
         return self.preview_cpc_annotations(self.user, self.source, cpc_files)

--- a/project/upload/tests/utils.py
+++ b/project/upload/tests/utils.py
@@ -26,11 +26,20 @@ class UploadAnnotationsTestMixin(object):
 
     @staticmethod
     def make_cpc_file(
-            cpc_filename, image_filepath, points,
+            dimensions, cpc_filename, image_filepath, points,
             codes_filepath=r'C:\PROGRA~4\CPCE_4~1\SHALLO~1.TXT'):
+        """
+        :param dimensions: image dimensions in pixels, as a (width, height)
+          tuple.
+        :param cpc_filename: filename of the .cpc to be created.
+        :param image_filepath: image filepath for line 1.
+        :param points: list of (column, row, label code) tuples.
+        :param codes_filepath: codes filepath for line 1.
+        """
         stream = StringIO()
         # Line 1
-        line1_nums = '3000,1500,9000,4500'
+        line1_nums = '{},{},9000,4500'.format(
+            dimensions[0]*15, dimensions[1]*15)
         stream.writelines([
             '"{codes_filepath}","{image_filepath}",{line1_nums}\n'.format(
                 codes_filepath=codes_filepath,

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -36,19 +36,27 @@
    TIP: If you are only interested in Confirmed annotations, then first do an image search with "Annotation status" set to "Confirmed", and then export annotations.</li>
 
   <li>
-    <strong>Annotations, CPCe:</strong> (Requires source Edit permissions) Annotations as .cpc files which can be opened in Coral Point Count. There will be one .cpc file per image, and the .cpc files will be contained in a .zip archive file. If you're not familiar with opening .zip files, see <a href="https://www.wikihow.com/Open-a-Zip-File" target="_blank">this WikiHow article</a>. The .cpc file format contains several pieces of information besides point positions and labels; here's how we handle each one:
+    <strong>Annotations, CPCe:</strong> (Requires source Edit permissions) Annotations as .cpc files which can be opened in Coral Point Count. There will be one .cpc file per image, and the .cpc files will be contained in a .zip archive file. If you're not familiar with opening .zip files, see <a href="https://www.wikihow.com/Open-a-Zip-File" target="_blank">this WikiHow article</a>. Here are the basics:
 
     <ul>
-      <li>Notes codes: Coral Point Count has a Notes column in the list of points, and the Notes codes you enter in this column are saved in the .cpc file. This info is available based on .cpc files you've previously uploaded. If you have uploaded a .cpc file for a particular CoralNet image, that .cpc file's Notes codes will be retained, and those Notes codes will be used when you request a .cpc export for that image. If you have never uploaded a .cpc file for this CoralNet image, the Notes codes will be blank.</li>
+      <li>We save your previously-uploaded .cpc files for each image, as long as the image's point locations have not been overwritten since the .cpc was uploaded.</li>
+      <li>If we have a saved .cpc file for a particular image, the .cpc you export here will be the same as the original .cpc, except that the point annotations will be updated to match the annotations on CoralNet.</li>
+      <li>If we do not have a saved .cpc file for an image, we create a .cpc file from scratch. Note that there are .cpc file format differences between versions of CPCe, and the .cpc files we create are meant for CPCe 4.1, the latest version. For example, if you try to open one of our .cpc files in CPCe 3.5 with a screen size setting of 120 DPI, then the point locations will be wrong.</li>
+    </ul>
 
-      <li>Header data: When you create a .cpc file in Coral Point Count, at some point it shows a window with 28 header fields such as Project name, Site name, Latitude, Easting, etc. Similarly to the Notes codes, this info is available based on .cpc files you've previously uploaded. (You might notice that these header fields have some overlap with CoralNet's metadata fields, but CoralNet does not currently make any connection between these fields on import/export.)</li>
+    The .cpc file format contains several pieces of information besides point positions and labels; here's how we handle each one:
+
+    <ul>
+      <li>Notes codes: Coral Point Count has a Notes column in the list of points. If a particular CoralNet image has a .cpc file saved, that .cpc file's Notes codes will be retained. If the image does not have a .cpc file saved, the Notes codes will be blank.</li>
+
+      <li>Header data: When you create a .cpc file in Coral Point Count (at least in CPCe 4.1), at some point it shows a window with 28 header fields such as Project name, Site name, Latitude, Easting, etc. If a particular CoralNet image has a .cpc file saved, that .cpc file's header values will be retained. Otherwise, we will fill in blank header values. (You might notice that these header fields have some overlap with CoralNet's metadata fields, but CoralNet does not make any connection between these two sets of fields on import/export.)</li>
 
       <li>
         Computer environment info: This includes the location of the .txt code file that CPCe uses to match label codes to label names/groups, and the location of the image file that was opened in CPCe. Unlike Notes codes and Header data, this environment info is necessary to make a .cpc work in Coral Point Count. Here's what CoralNet does to make sure this info is filled in:
 
         <ul>
-          <li>CoralNet first looks for this info in previously uploaded .cpc files.</li>
-          <li>If one or more images do not have a previous .cpc, then this action form will show form fields where you can fill in the environment values. These values will be automatically filled in with information from other images' uploaded .cpc files, if available. If no .cpc has been uploaded to this source before, then the fields will be blank and you'll have to fill them in.</li>
+          <li>CoralNet first looks for this info in saved .cpc files.</li>
+          <li>If one or more images do not have a saved .cpc, then this action form will show form fields where you can fill in the environment values. These values will be automatically filled in with information from other images' saved .cpc files, if available. If no images have .cpc files saved, then the fields will be blank and you'll have to fill them in.</li>
         </ul>
 
         If you have to fill in the environment info yourself, the code file location should look something like <code>C:\CPCe_41_inst\coral_codes.txt</code>, and the image folder location should look something like <code>C:\Image_data\Panama_corals</code> (you may have a slash at the end or not). Note that the image folder is a folder location, not a file location; the actual image file might be at C:\Image_data\Panama_corals\DSC_0048.JPG.


### PR DESCRIPTION
Addresses issue #326.

- Detect the correct pixel scale factor (typically 15, known to sometimes be 12 in CPCe 3.5) based on the image resolution and the first 2 numbers on line 1 of the .cpc.
- Another minor thing related to different CPCe versions: ensure that we don't care if the 28 header values are present at the end of the file or not. CPCe 4.1 has them, CPCe 3.5 doesn't seem to have them. The behavior here was already OK, but I just made the tests more explicit.
- Update CPC upload help text.