### PR TITLE
Thumbnails: rotation fix, and better file reuse

### DIFF
--- a/project/annotations/templates/annotations/annotation_area_edit.html
+++ b/project/annotations/templates/annotations/annotation_area_edit.html
@@ -32,8 +32,17 @@
     </form>
 
     <div id="image_container">
-        <img id="image" src="{% thumbnail image.original_file thumbnail_dimensions %}" />
-        <div id="annoarea_box"></div>
+      {% if has_thumbnail %}
+        <img id="image"
+             src="{% thumbnail image.original_file thumbnail_dimensions %}"
+             alt="{{ image.metadata.name }}" />
+      {% else %}
+        <img id="image"
+             src="{{ image.original_file.url }}"
+             alt="{{ image.metadata.name }}" />
+      {% endif %}
+
+      <div id="annoarea_box"></div>
     </div>
 
     <!-- Script in the body will run on page load. -->

--- a/project/annotations/templates/annotations/annotation_tool.html
+++ b/project/annotations/templates/annotations/annotation_tool.html
@@ -251,8 +251,8 @@
     AnnotationToolHelper.init({
         fullHeight: {{ image.original_height }},
         fullWidth: {{ image.original_width }},
-        IMAGE_AREA_WIDTH: {{ IMAGE_AREA_WIDTH }},
-        IMAGE_AREA_HEIGHT: {{ IMAGE_AREA_HEIGHT }},
+        IMAGE_AREA_WIDTH: 850,
+        IMAGE_AREA_HEIGHT: 650,
         imagePoints: {{ points|jsonify }},
         labels: {{ labels|jsonify }},
         machineSuggestions: {{ label_scores|jsonify }},

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -84,6 +84,15 @@ def annotation_area_edit(request, image_id):
 
     # Scale down the image to have a max width of 800 pixels.
     MAX_DISPLAY_WIDTH = 800
+    if image.original_width > MAX_DISPLAY_WIDTH:
+        # Parameters into the easy_thumbnails template tag:
+        # (specific width, height that keeps the aspect ratio)
+        thumbnail_dimensions = (MAX_DISPLAY_WIDTH, 0)
+        has_thumbnail = True
+    else:
+        # No thumbnail needed
+        thumbnail_dimensions = None
+        has_thumbnail = False
 
     # jQuery UI resizing with containment isn't subpixel-precise, so
     # the display height is rounded to an int.  Thus, need to track
@@ -101,12 +110,12 @@ def annotation_area_edit(request, image_id):
         widthScaleFactor=width_scale_factor,
         heightScaleFactor=height_scale_factor,
     )
-    thumbnail_dimensions = (display_width, display_height)
 
     return render(request, 'annotations/annotation_area_edit.html', {
         'source': source,
         'image': image,
         'dimensions': json.dumps(dimensions),
+        'has_thumbnail': has_thumbnail,
         'thumbnail_dimensions': thumbnail_dimensions,
         'annotationAreaForm': annotation_area_form,
     })

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -219,19 +219,17 @@ def annotation_tool(request, image_id):
     # Image tools form (brightness, contrast, etc.)
     image_options_form = AnnotationImageOptionsForm()
 
-    # Image dimensions.
-    IMAGE_AREA_WIDTH = 850
-    IMAGE_AREA_HEIGHT = 650
-
+    # Info on full image and scaled image, if any.
     source_images = dict(full=dict(
         url=image.original_file.url,
         width=image.original_file.width,
         height=image.original_file.height,
     ))
-    if image.original_width > IMAGE_AREA_WIDTH:
+    THUMBNAIL_WIDTH = 800
+    if image.original_width > THUMBNAIL_WIDTH:
         # Set scaled image's dimensions
         # (Specific width, height that keeps the aspect ratio)
-        thumbnail_dimensions = (IMAGE_AREA_WIDTH, 0)
+        thumbnail_dimensions = (THUMBNAIL_WIDTH, 0)
 
         # Generate the thumbnail if it doesn't exist,
         # and get the thumbnail's URL and dimensions.
@@ -264,8 +262,6 @@ def annotation_tool(request, image_id):
         'image_options_form': image_options_form,
         'points': points,
         'label_scores': label_scores,
-        'IMAGE_AREA_WIDTH': IMAGE_AREA_WIDTH,
-        'IMAGE_AREA_HEIGHT': IMAGE_AREA_HEIGHT,
         'source_images': source_images,
     })
 

--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -494,6 +494,15 @@ REST_FRAMEWORK = {
 MAX_CONCURRENT_API_JOBS_PER_USER = 5
 
 
+# easy-thumbnails setting.
+THUMBNAIL_DEFAULT_OPTIONS = {
+    # We don't rotate images according to EXIF orientation, since that would
+    # cause confusion in terms of point positions and annotation area.
+    # For consistency, here we apply this policy to thumbnails too, not just
+    # original images.
+    'exif_orientation': False,
+}
+
 # [Custom settings]
 # Media filepath patterns
 IMAGE_FILE_PATTERN = 'images/{name}{extension}'

--- a/project/images/tests/test_models.py
+++ b/project/images/tests/test_models.py
@@ -1,12 +1,92 @@
 from __future__ import unicode_literals
+from io import BytesIO
 import mock
 
+from django.core.files.base import ContentFile
 from django_migration_testcase import MigrationTest
+from easy_thumbnails.files import get_thumbnailer
+import piexif
+from PIL import Image as PILImage
 
 from annotations.model_utils import AnnotationAreaUtils
 from images.models import Point
 from images.model_utils import PointGen
 from lib.tests.utils import ClientTest
+
+
+class ImageExifOrientationTest(ClientTest):
+    """
+    Test images with EXIF orientation.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super(ImageExifOrientationTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        labels = cls.create_labels(cls.user, ['label1'], 'group1')
+        cls.labelset = cls.create_labelset(cls.user, cls.source, labels)
+
+    def test_thumbnail_doesnt_use_exif_orientation(self):
+        """
+        Generated thumbnails should ignore the original image's EXIF
+        orientation.
+        """
+        # Create an image with:
+        # - A blue background
+        # - 1 corner filled with red pixels
+        blue_color = (0, 0, 255)
+        red_color = (255, 0, 0)
+
+        # EXIF specifying 90-degree right rotation
+        zeroth_ifd = {piexif.ImageIFD.Orientation: 8}
+        exif_dict = {'0th': zeroth_ifd}
+        exif_bytes = piexif.dump(exif_dict)
+
+        with PILImage.new('RGB', (100, 70), color=blue_color) as im:
+            upper_left_20_by_20 = (0, 0, 20, 20)
+            im.paste(red_color, upper_left_20_by_20)
+
+            # Save image
+            with BytesIO() as stream:
+                im.save(stream, 'JPEG', exif=exif_bytes)
+                image_file = ContentFile(stream.getvalue(), name='1.jpg')
+
+        # Upload image
+        img = self.upload_image(self.user, self.source, image_file=image_file)
+
+        with PILImage.open(img.original_file) as im:
+            exif_dict = piexif.load(im.info['exif'])
+        self.assertEqual(
+            exif_dict['0th'][piexif.ImageIFD.Orientation], 8,
+            "Image should be saved with EXIF orientation")
+
+        # Generate thumbnail of 50-pixel width
+        opts = {'size': (50, 0)}
+        thumbnail = get_thumbnailer(img.original_file).get_thumbnail(opts)
+
+        # Check thumbnail file
+        with PILImage.open(thumbnail.file) as thumb_im:
+            self.assertEqual(
+                thumb_im.size, (50, 35),
+                "Thumbnail dimensions should have the same aspect ratio as"
+                " the original image, un-rotated")
+            self.assertNotIn(
+                'exif', thumb_im.info,
+                "Thumbnail should not have EXIF (we just want it to not have"
+                " non-default EXIF orientation, but the actual result is that"
+                " there is no EXIF, so we check for that)")
+
+            # Check thumbnail file content. This is all JPEG, so we don't
+            # expect exact color matches, but this code should manage to check
+            # which corner is the red corner.
+            upper_left_pixel = thumb_im.getpixel((0, 0))
+            upper_left_r_greater_than_b = \
+                upper_left_pixel[0] > upper_left_pixel[2]
+            self.assertTrue(
+                upper_left_r_greater_than_b,
+                "Red corner should be the same corner as in the original"
+                " image, indicating that the thumbnail content is un-rotated")
 
 
 class PointValidationTest(ClientTest):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,6 +26,12 @@ django-guardian==1.4.9
 # django-andablog, as of 3.1.0, still needs Pillow 4.x instead of >= 5
 Pillow==4.3.0
 
+# Image EXIF reading/writing
+# Could be replaced with Pillow once Pillow is 6.0 or higher, since they
+# added EXIF writing support then.
+# Changelog: https://piexif.readthedocs.io/en/latest/changes.html
+piexif==1.1.3
+
 # Markdown support in the blog and other places.
 # Changelog: https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/index.md
 Markdown>=3.1.1,<4


### PR DESCRIPTION
I figured it'd be best to address issue #332 before advising people to double check a bunch of images, because when you load the annotation tool, it generally takes several seconds for the thumbnail to get replaced by the full image. If the thumbnail is the wrong orientation, and the user is a fast checker, then they might check the points against the wrong image orientation.

While I was at it, I consolidated some very similar thumbnail sizes (image detail, annotation tool, annotation area edit) to reduce thumbnail storage volume and generation time.