### PR TITLE
API monitoring for site admins + Admin tools portal

### DIFF
--- a/project/api_management/templates/api_management/job_detail.html
+++ b/project/api_management/templates/api_management/job_detail.html
@@ -51,8 +51,14 @@ tr[data-status="{{ FAILURE }}"] {
         <td>{{ unit.id }}</td>
         <td>{{ unit.type }}</td>
         <td>{{ unit.status_display }}</td>
-        <td>{{ unit.request_json_display|linebreaks }}</td>
-        <td>{{ unit.error_display|linebreaks }}</td>
+        <td>
+          <ul class="detail_list">
+            {% for rj_string in unit.request_json_strings %}
+              <li>{{ rj_string }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td>{{ unit.error_display }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/project/api_management/templates/api_management/job_detail.html
+++ b/project/api_management/templates/api_management/job_detail.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}API Job {{ job.id }} | CoralNet{% endblock %}
+
+
+{% block css-code %}
+<style type="text/css">
+tr[data-status="{{ PENDING }}"] {
+  background-color: #bbe;
+}
+tr[data-status="{{ IN_PROGRESS }}"] {
+  background-color: #eeb;
+}
+tr[data-status="{{ SUCCESS }}"] {
+  background-color: #beb;
+}
+tr[data-status="{{ FAILURE }}"] {
+  background-color: #ebb;
+}
+</style>
+{% endblock %}
+
+
+{% block content %}
+
+<h1>API Job {{ job.id }}</h1>
+
+<ul class="detail_list">
+  <li>Job request date: {{ job.create_date }}</li>
+  <li>User who requested the job: {{ job.user }}</li>
+  <li>Job type: {{ job.type }}</li>
+  <li>Overall status: {{ job_status.overall_status }}</li>
+</ul>
+<br>
+
+<h2>Unit statuses</h2>
+
+<table class="generic">
+  <thead>
+    <tr>
+      <th title="Unit ID">ID</th>
+      <th title="Unit type">Type</th>
+      <th title="Progress status">Status</th>
+      <th title="JSON with request details">Request JSON</th>
+      <th title="Error message">Error</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for unit in units %}
+      <tr data-status="{{ unit.status }}">
+        <td>{{ unit.id }}</td>
+        <td>{{ unit.type }}</td>
+        <td>{{ unit.status_display }}</td>
+        <td>{{ unit.request_json_display|linebreaks }}</td>
+        <td>{{ unit.error_display|linebreaks }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/project/api_management/templates/api_management/job_list.html
+++ b/project/api_management/templates/api_management/job_list.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}API Jobs | CoralNet{% endblock %}
+
+
+{% block css-code %}
+<style type="text/css">
+tr[data-status="{{ PENDING }}"] {
+  background-color: #bbe;
+}
+tr[data-status="{{ IN_PROGRESS }}"] {
+  background-color: #eeb;
+}
+tr[data-status="{{ DONE }}"] {
+  background-color: #beb;
+}
+td.failure {
+  background-color: #ebb;
+}
+</style>
+{% endblock %}
+
+
+{% block content %}
+
+<h1>API Jobs</h1>
+
+<p>{{ in_progress_count }} jobs in progress, {{ pending_count }} pending, {{ done_count }} completed in the last month.</p>
+
+<table class="generic">
+  <thead>
+    <tr>
+      <th title="Database ID">ID</th>
+      <th title="Job request date">Create date</th>
+      <th title="User who requested the job">User</th>
+      <th title="Job type">Type</th>
+      <th title="Progress status">Status</th>
+      <th title="Unfinished units">Unfinished</th>
+      <th title="Units finished with failure">Failed</th>
+      <th title="Units finished with success">Succeeded</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for job in jobs %}
+      <tr data-status="{{ job.overall_status }}">
+        <td>
+          <a href="{% url 'api_management:job_detail' job.id %}">
+            {{ job.id }}
+          </a>
+        </td>
+        <td>{{ job.create_date }}</td>
+        <td>{{ job.user }}</td>
+        <td>{{ job.type }}</td>
+        <td>{{ job.overall_status }}</td>
+        <td>{{ job.pending_units|add:job.in_progress_units }}</td>
+        <td class="{% if job.failure_units > 0 %} failure {% endif %}">
+          {{ job.failure_units }}
+        </td>
+        <td>{{ job.success_units }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/project/api_management/tests.py
+++ b/project/api_management/tests.py
@@ -1,0 +1,292 @@
+from __future__ import unicode_literals
+
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from api_core.models import ApiJob, ApiJobUnit
+from lib.tests.utils import BasePermissionTest, ClientTest
+
+
+class PermissionTest(BasePermissionTest):
+
+    def test_job_list(self):
+        url = reverse('api_management:job_list')
+        template = 'api_management/job_list.html'
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SUPERUSER, template=template,
+            deny_type=self.REQUIRE_LOGIN)
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SUPERUSER, template=template,
+            deny_type=self.REQUIRE_LOGIN)
+
+    def test_job_detail(self):
+        job = ApiJob(type='test', user=self.user)
+        job.save()
+        url = reverse('api_management:job_detail', args=[job.pk])
+        template = 'api_management/job_detail.html'
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SUPERUSER, template=template,
+            deny_type=self.REQUIRE_LOGIN)
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SUPERUSER, template=template,
+            deny_type=self.REQUIRE_LOGIN)
+
+
+class JobListTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(JobListTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+
+    def test_all_table_columns(self):
+        job = ApiJob(type='test_job_type', user=self.user)
+        job.save()
+
+        # Create job units of various statuses
+        unit_statuses = (
+            [ApiJobUnit.PENDING]*4 + [ApiJobUnit.IN_PROGRESS]*3
+            + [ApiJobUnit.FAILURE]*2 + [ApiJobUnit.SUCCESS])
+        for status in unit_statuses:
+            unit = ApiJobUnit(
+                job=job, type='test_unit_type', status=status, request_json={})
+            unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('api_management:job_list'))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        job_row = response_soup.find('tbody').find('tr')
+        cells_text = [
+            td.get_text().strip() for td in job_row.find_all('td')]
+
+        self.assertEqual(cells_text[0], str(job.pk))
+        # Date; we just check that it shows something
+        self.assertNotEqual(cells_text[1], '')
+        self.assertEqual(cells_text[2], self.user.username)
+        self.assertEqual(cells_text[3], 'test_job_type')
+        self.assertEqual(cells_text[4], ApiJob.IN_PROGRESS)
+        # 4 pending + 3 in progress
+        self.assertEqual(cells_text[5], '7')
+        # Failures
+        self.assertEqual(cells_text[6], '2')
+        # Successes
+        self.assertEqual(cells_text[7], '1')
+
+    def test_all_job_statuses(self):
+        pending_job = ApiJob(type='test', user=self.user)
+        pending_job.save()
+        unit = ApiJobUnit(
+            job=pending_job, type='test', status=ApiJobUnit.PENDING,
+            request_json={})
+        unit.save()
+
+        in_progress_job = ApiJob(type='test', user=self.user)
+        in_progress_job.save()
+        unit = ApiJobUnit(
+            job=in_progress_job, type='test', status=ApiJobUnit.IN_PROGRESS,
+            request_json={})
+        unit.save()
+
+        done_with_fails_job = ApiJob(type='test', user=self.user)
+        done_with_fails_job.save()
+        unit = ApiJobUnit(
+            job=done_with_fails_job, type='test', status=ApiJobUnit.SUCCESS,
+            request_json={})
+        unit.save()
+        unit = ApiJobUnit(
+            job=done_with_fails_job, type='test', status=ApiJobUnit.FAILURE,
+            request_json={})
+        unit.save()
+
+        done_success_job = ApiJob(type='test', user=self.user)
+        done_success_job.save()
+        unit = ApiJobUnit(
+            job=done_success_job, type='test', status=ApiJobUnit.SUCCESS,
+            request_json={})
+        unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('api_management:job_list'))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        job_rows = response_soup.find('tbody').find_all('tr')
+        cells_text = [
+            [td.get_text().strip() for td in row.find_all('td')]
+            for row in job_rows]
+
+        # Jobs are ordered by status: in progress, then pending, then done
+        self.assertEqual(cells_text[0][0], str(in_progress_job.pk))
+        self.assertEqual(cells_text[0][4], ApiJob.IN_PROGRESS)
+        self.assertEqual(cells_text[1][0], str(pending_job.pk))
+        self.assertEqual(cells_text[1][4], ApiJob.PENDING)
+        # For jobs of the same status, latest ID first
+        self.assertEqual(cells_text[2][0], str(done_success_job.pk))
+        self.assertEqual(cells_text[2][4], ApiJob.DONE)
+        self.assertEqual(cells_text[3][0], str(done_with_fails_job.pk))
+        self.assertEqual(cells_text[3][4], ApiJob.DONE)
+
+
+class JobDetailTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(JobDetailTest, cls).setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        cls.classifier = cls.create_robot(cls.source)
+
+        cls.sample_request_json = dict(
+            classifier_id=cls.classifier.pk,
+            url='my/url',
+            points=[dict(row=20, column=30), dict(row=40, column=50)],
+        )
+        cls.sample_result_json_with_error = dict(
+            error="Error goes here",
+        )
+
+    def test_all_table_columns(self):
+        job = ApiJob(type='test_job_type', user=self.user)
+        job.save()
+
+        unit = ApiJobUnit(
+            job=job, type='test_unit_type', status=ApiJobUnit.FAILURE,
+            request_json=self.sample_request_json,
+            result_json=self.sample_result_json_with_error)
+        unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse('api_management:job_detail', args=[job.pk]))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        unit_row = response_soup.find('tbody').find('tr')
+        cells = unit_row.find_all('td')
+        cells_text = [cell.get_text().strip() for cell in cells]
+
+        request_json_as_html = (
+            "Classifier ID {} (Source ID {})".format(
+                self.classifier.pk, self.source.pk)
+            + "<br>URL: my/url"
+            + "<br>Point count: 2")
+
+        self.assertEqual(cells_text[0], str(unit.pk))
+        self.assertEqual(cells_text[1], 'test_unit_type')
+        self.assertEqual(cells_text[2], "Failure")
+        self.assertInHTML(
+            request_json_as_html, str(cells[3]))
+        self.assertEqual(cells_text[4], "Error goes here")
+
+    def test_deleted_classifier(self):
+        classifier = self.create_robot(self.source)
+        classifier_id = classifier.pk
+        classifier.delete()
+
+        job = ApiJob(type='test', user=self.user)
+        job.save()
+
+        request_json = self.sample_request_json.copy()
+        request_json['classifier_id'] = classifier_id
+
+        unit = ApiJobUnit(
+            job=job, type='test', status=ApiJobUnit.FAILURE,
+            request_json=request_json,
+            result_json=self.sample_result_json_with_error)
+        unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse('api_management:job_detail', args=[job.pk]))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        unit_row = response_soup.find('tbody').find('tr')
+        cells = unit_row.find_all('td')
+
+        request_json_as_html = (
+            "Classifier ID {} (deleted)".format(classifier_id)
+            + "<br>URL: my/url"
+            + "<br>Point count: 2")
+        self.assertInHTML(
+            request_json_as_html, str(cells[3]))
+
+    def test_no_errors(self):
+        job = ApiJob(type='test_job_type', user=self.user)
+        job.save()
+
+        unit = ApiJobUnit(
+            job=job, type='test_unit_type', status=ApiJobUnit.SUCCESS,
+            request_json=self.sample_request_json,
+            result_json={})
+        unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse('api_management:job_detail', args=[job.pk]))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        unit_row = response_soup.find('tbody').find('tr')
+        cells = unit_row.find_all('td')
+        cells_text = [cell.get_text().strip() for cell in cells]
+
+        self.assertEqual(cells_text[4], "", "Error cell should be blank")
+
+    def test_no_result_json(self):
+        """
+        Unfinished job units won't have any result_json set yet.
+        """
+        job = ApiJob(type='test_job_type', user=self.user)
+        job.save()
+
+        unit = ApiJobUnit(
+            job=job, type='test_unit_type', status=ApiJobUnit.IN_PROGRESS,
+            request_json=self.sample_request_json)
+        unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse('api_management:job_detail', args=[job.pk]))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        unit_row = response_soup.find('tbody').find('tr')
+        cells = unit_row.find_all('td')
+        cells_text = [cell.get_text().strip() for cell in cells]
+
+        self.assertEqual(cells_text[4], "", "Error cell should be blank")
+
+    def test_all_unit_statuses(self):
+        job = ApiJob(type='test_job_type', user=self.user)
+        job.save()
+
+        # Create job units of various statuses
+        unit_statuses = [
+            ApiJobUnit.PENDING, ApiJobUnit.IN_PROGRESS,
+            ApiJobUnit.FAILURE, ApiJobUnit.SUCCESS]
+        for status in unit_statuses:
+            unit = ApiJobUnit(
+                job=job, type='test_unit_type', status=status,
+                request_json=self.sample_request_json)
+            unit.save()
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(
+            reverse('api_management:job_detail', args=[job.pk]))
+
+        response_soup = BeautifulSoup(response.content, 'html.parser')
+        unit_rows = response_soup.find('tbody').find_all('tr')
+        cells_text = [
+            [td.get_text().strip() for td in row.find_all('td')]
+            for row in unit_rows]
+
+        # Units should be ordered latest to earliest
+        self.assertEqual(cells_text[0][2], "Success")
+        self.assertEqual(cells_text[1][2], "Failure")
+        self.assertEqual(cells_text[2][2], "In Progress")
+        self.assertEqual(cells_text[3][2], "Pending")

--- a/project/api_management/tests.py
+++ b/project/api_management/tests.py
@@ -173,16 +173,16 @@ class JobDetailTest(ClientTest):
         cells_text = [cell.get_text().strip() for cell in cells]
 
         request_json_as_html = (
-            "Classifier ID {} (Source ID {})".format(
+            "<li>Classifier ID {} (Source ID {})</li>".format(
                 self.classifier.pk, self.source.pk)
-            + "<br>URL: my/url"
-            + "<br>Point count: 2")
+            + "<li>URL: my/url</li>"
+            + "<li>Point count: 2</li>")
 
         self.assertEqual(cells_text[0], str(unit.pk))
         self.assertEqual(cells_text[1], 'test_unit_type')
         self.assertEqual(cells_text[2], "Failure")
         self.assertInHTML(
-            request_json_as_html, str(cells[3]))
+            request_json_as_html, str(cells[3].find('ul')))
         self.assertEqual(cells_text[4], "Error goes here")
 
     def test_deleted_classifier(self):
@@ -211,11 +211,11 @@ class JobDetailTest(ClientTest):
         cells = unit_row.find_all('td')
 
         request_json_as_html = (
-            "Classifier ID {} (deleted)".format(classifier_id)
-            + "<br>URL: my/url"
-            + "<br>Point count: 2")
+            "<li>Classifier ID {} (deleted)</li>".format(classifier_id)
+            + "<li>URL: my/url</li>"
+            + "<li>Point count: 2</li>")
         self.assertInHTML(
-            request_json_as_html, str(cells[3]))
+            request_json_as_html, str(cells[3].find('ul')))
 
     def test_no_errors(self):
         job = ApiJob(type='test_job_type', user=self.user)

--- a/project/api_management/urls.py
+++ b/project/api_management/urls.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^jobs/$',
+        views.job_list, name='job_list'),
+    url(r'^jobs/(?P<job_id>\d+)/$',
+        views.job_detail, name='job_detail'),
+]

--- a/project/api_management/views.py
+++ b/project/api_management/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.decorators import permission_required
 from django.shortcuts import get_object_or_404, render
 
 from api_core.models import ApiJob, ApiJobUnit
-from vision_backend_api.utils import deploy_request_json_display
+from vision_backend_api.utils import deploy_request_json_as_strings
 
 
 @permission_required('is_superuser')
@@ -55,7 +55,7 @@ def job_detail(request, job_id):
 
         # Here we assume it's a deploy job. If we expand the API to different
         # job types later, then this code has to become more flexible.
-        request_json_display = deploy_request_json_display(unit_obj)
+        request_json_strings = deploy_request_json_as_strings(unit_obj)
 
         if unit_obj.result_json:
             error_display = unit_obj.result_json.get('error', '')
@@ -67,7 +67,7 @@ def job_detail(request, job_id):
             type=unit_obj.type,
             status=unit_obj.status,
             status_display=unit_obj.get_status_display(),
-            request_json_display=request_json_display,
+            request_json_strings=request_json_strings,
             error_display=error_display,
         ))
 

--- a/project/api_management/views.py
+++ b/project/api_management/views.py
@@ -1,0 +1,82 @@
+from __future__ import unicode_literals
+
+from django.contrib.auth.decorators import permission_required
+from django.shortcuts import get_object_or_404, render
+
+from api_core.models import ApiJob, ApiJobUnit
+from vision_backend_api.utils import deploy_request_json_display
+
+
+@permission_required('is_superuser')
+def job_list(request):
+    """
+    Display a list of all API jobs.
+    """
+    pending_jobs = []
+    in_progress_jobs = []
+    done_jobs = []
+
+    # Order jobs by progress status, then by decreasing primary key.
+    for job in ApiJob.objects.all().order_by('-pk'):
+        job_info = job.full_status()
+        job_info['id'] = job.pk
+        job_info['create_date'] = job.create_date
+        job_info['user'] = job.user
+        job_info['type'] = job.type
+
+        if job_info['overall_status'] == ApiJob.PENDING:
+            pending_jobs.append(job_info)
+        elif job_info['overall_status'] == ApiJob.IN_PROGRESS:
+            in_progress_jobs.append(job_info)
+        else:
+            done_jobs.append(job_info)
+
+    return render(request, 'api_management/job_list.html', {
+        'jobs': in_progress_jobs + pending_jobs + done_jobs,
+        'in_progress_count': len(in_progress_jobs),
+        'pending_count': len(pending_jobs),
+        'done_count': len(done_jobs),
+        'PENDING': ApiJob.PENDING,
+        'IN_PROGRESS': ApiJob.IN_PROGRESS,
+        'DONE': ApiJob.DONE,
+    })
+
+
+@permission_required('is_superuser')
+def job_detail(request, job_id):
+    """
+    Display details of a particular job, including a table of its job units.
+    """
+    job = get_object_or_404(ApiJob, id=job_id)
+    job_status = job.full_status()
+
+    units = []
+    for unit_obj in job.apijobunit_set.all().order_by('-pk'):
+
+        # Here we assume it's a deploy job. If we expand the API to different
+        # job types later, then this code has to become more flexible.
+        request_json_display = deploy_request_json_display(unit_obj)
+
+        if unit_obj.result_json:
+            error_display = unit_obj.result_json.get('error', '')
+        else:
+            error_display = ''
+
+        units.append(dict(
+            id=unit_obj.pk,
+            type=unit_obj.type,
+            status=unit_obj.status,
+            status_display=unit_obj.get_status_display(),
+            request_json_display=request_json_display,
+            error_display=error_display,
+        ))
+
+    return render(request, 'api_management/job_detail.html', {
+        'job': job,
+        'job_status': job_status,
+        'units': units,
+        'PENDING': ApiJobUnit.PENDING,
+        'IN_PROGRESS': ApiJobUnit.IN_PROGRESS,
+        'SUCCESS': ApiJobUnit.SUCCESS,
+        'FAILURE': ApiJobUnit.FAILURE,
+    })

--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -156,6 +156,7 @@ INSTALLED_APPS = [
     'accounts',
     'annotations',
     'api_core',
+    'api_management',
     'async_media',
     'blog',
     'bug_reporting',

--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
         include('api_management.urls', namespace='api_management')),
 
     # "Secret" dev views
+    url(r'^admin_tools/$', lib_views.admin_tools, name="admin_tools"),
     url(r'^nav_test/(?P<source_id>\d+)/$', lib_views.nav_test, name="nav_test"),
     url(r'^backend_overview$', backend_views.backend_overview, name="backend_overview"),
     url(r'^cm_test$', backend_views.cm_test, name="cm_test"),

--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -45,6 +45,8 @@ urlpatterns = [
 
     # API
     url(r'^api/', include('api_core.urls', namespace='api')),
+    url(r'^api_management/',
+        include('api_management.urls', namespace='api_management')),
 
     # "Secret" dev views
     url(r'^nav_test/(?P<source_id>\d+)/$', lib_views.nav_test, name="nav_test"),

--- a/project/lib/templates/lib/admin_tools.html
+++ b/project/lib/templates/lib/admin_tools.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Tools | CoralNet{% endblock %}
+
+
+{% block content %}
+
+<h1>Admin Tools</h1>
+
+<ul class="detail_list">
+  <li><a href="{% url 'admin:index' %}">Admin site</a></li>
+  <li><a href="{% url 'api_management:job_list' %}">API jobs</a></li>
+  <li><a href="{% url 'backend_overview' %}">Backend overview</a></li>
+  <li><a href="{% url 'cm_test' %}">Confusion matrix test</a></li>
+  <li><a href="{% url 'labelset_duplicates' %}">Duplicate labels</a></li>
+  <li><a href="{% url 'emailall' %}">Email all</a></li>
+</ul>
+
+{% endblock %}

--- a/project/lib/tests/tests.py
+++ b/project/lib/tests/tests.py
@@ -44,6 +44,14 @@ class PermissionTest(BasePermissionTest):
 
         self.assertPermissionLevel(url, self.SIGNED_OUT, template=template)
 
+    def test_admin_tools(self):
+        url = reverse('admin_tools')
+        template = 'lib/admin_tools.html'
+
+        self.assertPermissionLevel(
+            url, self.SUPERUSER, template=template,
+            deny_type=self.REQUIRE_LOGIN)
+
     def test_nav_test(self):
         url = reverse('nav_test', args=[self.source.pk])
         template = 'lib/nav_test.html'

--- a/project/lib/views.py
+++ b/project/lib/views.py
@@ -36,6 +36,14 @@ def index(request):
     })
 
 
+@permission_required('is_superuser')
+def admin_tools(request):
+    """
+    Admin tools portal page.
+    """
+    return render(request, 'lib/admin_tools.html')
+
+
 def handler500(request, template_name='500.html'):
     try:
         template = loader.get_template(template_name)

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -96,7 +96,9 @@
               {% endwith %}
 
               {% if user.is_superuser %}
-	              <li><a href="{% url 'emailall' %}"><span>Email All</span></a></li>
+	              <li><a href="{% url 'admin_tools' %}">
+                  <span>Admin Tools</span>
+                </a></li>
               {% endif %}
 
               <li><a href="{% url 'profile_detail' user.pk %}"><span>Account ({{ user.username }})</span></a></li>

--- a/project/vision_backend_api/utils.py
+++ b/project/vision_backend_api/utils.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 from vision_backend.models import Classifier
 
 
-def deploy_request_json_display(job):
+def deploy_request_json_as_strings(job):
     """
-    String display for a deploy job's request JSON.
+    Get a string list representing a deploy job's request JSON.
     """
     request_json = job.request_json
     classifier_id = request_json['classifier_id']
@@ -15,8 +15,8 @@ def deploy_request_json_display(job):
     except Classifier.DoesNotExist:
         classifier_display = "Classifier ID {} (deleted)".format(classifier_id)
 
-    return (
-        classifier_display
-        + "\nURL: {}".format(request_json['url'])
-        + "\nPoint count: {}".format(len(request_json['points']))
-    )
+    return [
+        classifier_display,
+        "URL: {}".format(request_json['url']),
+        "Point count: {}".format(len(request_json['points'])),
+    ]

--- a/project/vision_backend_api/utils.py
+++ b/project/vision_backend_api/utils.py
@@ -1,0 +1,22 @@
+from __future__ import unicode_literals
+from vision_backend.models import Classifier
+
+
+def deploy_request_json_display(job):
+    """
+    String display for a deploy job's request JSON.
+    """
+    request_json = job.request_json
+    classifier_id = request_json['classifier_id']
+    try:
+        classifier = Classifier.objects.get(pk=classifier_id)
+        classifier_display = "Classifier ID {} (Source ID {})".format(
+            classifier_id, classifier.source.pk)
+    except Classifier.DoesNotExist:
+        classifier_display = "Classifier ID {} (deleted)".format(classifier_id)
+
+    return (
+        classifier_display
+        + "\nURL: {}".format(request_json['url'])
+        + "\nPoint count: {}".format(len(request_json['points']))
+    )


### PR DESCRIPTION
Doing this now so we can help API beta testers more easily, and generally see how API usage is going.

Changes:

- Implement issue #293 (API job monitor for developers).

  - The pages created here could potentially also be used for issue #294 (API status info for users), by filtering `job_list` results and using more fine-grained permissions in `job_detail`, but I didn't implement that yet.

- Make an Admin Tools portal page which links all of our admin-facing pages, such as this API job monitor, backend overview, email-all form, etc. The 'Email All' button in the top bar is now replaced by an 'Admin Tools' button leading to this admin tools portal. This way we don't have to bookmark all those pages' URLs.

API job list page:

![job_list](https://user-images.githubusercontent.com/857711/86295754-2a7fa980-bbac-11ea-8040-145e191642e3.png)

API job detail page:

![job_detail](https://user-images.githubusercontent.com/857711/86295775-34091180-bbac-11ea-96b8-35a9029acc84.png)
