### PR TITLE
Skip RemovePointOutliersTest due to unreliability

### DIFF
--- a/project/images/tests/test_commands.py
+++ b/project/images/tests/test_commands.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import mock
 import os
 import tempfile
+from unittest import skip
 
 from images.model_utils import PointGen
 from images.models import Point
@@ -16,6 +17,10 @@ def save_without_checks(self, *args, **kwargs):
     super(Point, self).save(*args, **kwargs)
 
 
+@skip(
+    "This test is unreliable for some unknown reason, both on Windows dev"
+    " machine and on Travis. Example error:"
+    r" `AssertionError: '102 4' not found in '102 3\n103 4'`")
 class RemovePointOutliersTest(ManagementCommandTest):
 
     @staticmethod


### PR DESCRIPTION
Already done in beta2-rollout branch, but it should've been done in master branch instead.