### PR TITLE
Added an entry for saved vs trained robots on source main page

### DIFF
--- a/project/images/models.py
+++ b/project/images/models.py
@@ -362,16 +362,23 @@ class Source(models.Model):
         return AnnotationAreaUtils.db_format_to_display(
             self.image_annotation_area)
 
-    def get_latest_robot(self):
+    def get_latest_robot(self, only_valid=True):
         """
         return the latest robot associated with this source.
         if no robots, return None
         """
-        robots = self.get_valid_robots()
-        if robots.count() > 0:
-            return robots[0]
+        if only_valid:
+            robots = self.get_valid_robots()
+            if robots.count() > 0:
+                return robots[0]
+            else:
+                return None
         else:
-            return None
+            robots = Classifier.objects.filter(source=self).order_by('-id')
+            if robots.count() > 0:
+                return robots[0]
+            else:
+                return None
 
     def get_valid_robots(self):
         """

--- a/project/images/templates/images/source_main.html
+++ b/project/images/templates/images/source_main.html
@@ -83,7 +83,8 @@ $(document).ready(function() {
                     <li>Machine annotator: Disabled (can enable upon <a href="{{ forum_link }}">request</a>)</li>
                 {% else %}
                 {% if robot_stats.has_robot %}
-                    <li>Last classifier trained: {{robot_stats.create_date}}</li>
+                    <li>Last classifier saved: {{robot_stats.create_date_saved}}</li>
+                    <li>Last classifier trained: {{robot_stats.create_date_trained}}</li>
                 {% endif %}
             {% endif %}
             </ul>

--- a/project/images/views.py
+++ b/project/images/views.py
@@ -203,7 +203,10 @@ def source_main(request, source_id):
             })
         robot_stats['backend_plot_data'] = backend_plot_data
         robot_stats['has_robot'] = True
-        robot_stats['create_date'] = source.get_latest_robot().create_date
+        robot_stats['create_date_saved'] = source.get_latest_robot(
+            only_valid=True).create_date
+        robot_stats['create_date_trained'] = source.get_latest_robot(
+            only_valid=False).create_date
     else:
         robot_stats['has_robot'] = False
 


### PR DESCRIPTION
Implements suggestion in https://github.com/beijbom/coralnet/issues/341.

I wasn't able to fully test in the sense that I had a source with non-valid robots. But I checked that for source with valid robots it renders correctly.

<img width="1041" alt="Screen Shot 2020-08-18 at 10 03 40 PM" src="https://user-images.githubusercontent.com/1128855/90594191-b1a9d080-e19e-11ea-8e67-039a42853ba0.png">
