### PR TITLE
Annotation tool: Add another EXIF-loading error case

### DIFF
--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -26,7 +26,8 @@ var AnnotationToolImageHelper = (function() {
         }
         catch (e) {
             if (e.message.includes("invalid file data")
-                    || e.message.includes("'unpack' error")) {
+                    || e.message.includes("'unpack' error")
+                    || e.message.includes("incorrect value type to decode")) {
                 // piexifjs couldn't properly load the exif.
                 try {
                     // Since we can't edit the exif, Plan B: remove the


### PR DESCRIPTION
On the production site, if you visit image ID 1508487 in the annotation tool, you get this Javascript alert message:

> Error when loading the image: "Exif might be wrong. Got incorrect value type to decode. type:0" If the problem persists, please contact the admins.

This PR should fix that. We don't have automated tests for Javascript yet, though. To manually test, download image 1508487 from the production site, upload it to your development site, visit it in the annotation tool, and see if you get the above Javascript alert or not.