### PR TITLE
Change API points-per-image limit from 1000 to 200

### DIFF
--- a/project/vision_backend_api/forms.py
+++ b/project/vision_backend_api/forms.py
@@ -59,7 +59,7 @@ def validate_deploy(post_data):
         validate_array(
             image_spec['attributes']['points'],
             img_json_path + ['attributes', 'points'],
-            check_non_empty=True, max_length=1000)
+            check_non_empty=True, max_length=200)
 
         for pt_index, point in enumerate(image_spec['attributes']['points']):
 

--- a/project/vision_backend_api/tests/test_deploy.py
+++ b/project/vision_backend_api/tests/test_deploy.py
@@ -332,14 +332,14 @@ class DeployImagesParamErrorTest(DeployBaseTest):
 
     def test_too_many_points(self):
         images = [
-            dict(type='image', attributes=dict(url='URL 1', points=[{}]*1001))]
+            dict(type='image', attributes=dict(url='URL 1', points=[{}]*201))]
         data = json.dumps(dict(data=images))
         response = self.client.post(
             self.deploy_url, data, **self.request_kwargs)
 
         self.assert_expected_400_error(
             response, dict(
-                detail="This array exceeds the max length of 1000.",
+                detail="This array exceeds the max length of 200.",
                 source=dict(pointer='/data/0/attributes/points')))
 
     def test_point_not_hash(self):


### PR DESCRIPTION
From discussion in issue #277. Some API jobs have been getting stuck, and it seems like high points per image might be the culprit. New pyspacer is tested for 1000, but that's not rolled out yet. It seems like current spacer can handle 200.