### PR TITLE
Fix the source main page's links to Browse

### DIFF
--- a/project/images/views.py
+++ b/project/images/views.py
@@ -174,7 +174,8 @@ def source_main(request, source_id):
 
     def browse_link_filtered_by_status(annotation_status):
         return browse_url_base + '?' + urlencode(dict(
-            image_form_type='search', annotation_status=annotation_status))
+            image_form_type='search', annotation_status=annotation_status,
+            sort_direction='asc', sort_method='name'))
 
     image_stats = dict(
         total = all_images.count(),


### PR DESCRIPTION
The links were previously getting "Search parameters were invalid" and failing to show any results. I introduced this bug while adding the 'last annotated' filters.

Basically there are two new required fields in Browse now: `sort_method` and `sort_direction`. I neglected to update these links to include the new required fields. Maybe the Browse fields can be coded more nicely to not make this necessary, but that'll be a bigger refactor for another day, I think.

Hopefully this'll be the last master-branch fix before `beta2-rollout` is finally merged into master.