### PR TITLE
Re-enable server error emails to admins

### DIFF
--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -568,7 +568,8 @@ CELERY_RESULT_SERIALIZER = 'json'
 # LOG
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    # Existing (default) logging includes error emails to admins.
+    'disable_existing_loggers': False,
     'formatters': {
         'standard': {
             'format': '[%(name)s.%(funcName)s, %(asctime)s]: %(message)s'


### PR DESCRIPTION
Here's the commit that disabled it, apparently: https://github.com/beijbom/coralnet/commit/1b32830bfdb21a905e79eddad8f232187341a69c#diff-e2f4effca2ca9ed1d60f1fe03c005ecaf4e58bda4d87c321499f20753523c8b3

But I looked through PR #324 and couldn't figure out exactly where/why this change was made. Not sure if I'm missing anything.

I already re-enabled this on the production server since we've been missing error emails today.