### PR TITLE
removing outdated messages in queue stats from vision overview page

### DIFF
--- a/project/vision_backend/templates/vision_backend/overview.html
+++ b/project/vision_backend/templates/vision_backend/overview.html
@@ -7,7 +7,6 @@
 
 <p>There are {{clf_stats.nclassifiers}} trained classifieres out of which {{clf_stats.nvalidclassifiers}} are valid. This means there are on average {{clf_stats.valid_ratio}} valid classifiers per each of the {{clf_stats.nsources}} sources. </p>
 
-<p> There are currently {{q_stats.celery_scheduled}} scheduled celery tasks, {{q_stats.celery_active}} active celery tasks, and {{q_stats.celery_queued}} queued celery task.</p>
 <table class="detail_table_popup">
     <tr>
         <th>id</th>

--- a/project/vision_backend/templates/vision_backend/overview.html
+++ b/project/vision_backend/templates/vision_backend/overview.html
@@ -7,7 +7,7 @@
 
 <p>There are {{clf_stats.nclassifiers}} trained classifieres out of which {{clf_stats.nvalidclassifiers}} are valid. This means there are on average {{clf_stats.valid_ratio}} valid classifiers per each of the {{clf_stats.nsources}} sources. </p>
 
-<p> There are currently {{q_stats.spacer}} jobs in the Spacer queue, {{q_stats.celery_scheduled}} scheduled celery tasks, {{q_stats.celery_active}} active celery tasks, and {{q_stats.celery_queued}} queued celery task.</p>
+<p> There are currently {{q_stats.celery_scheduled}} scheduled celery tasks, {{q_stats.celery_active}} active celery tasks, and {{q_stats.celery_queued}} queued celery task.</p>
 <table class="detail_table_popup">
     <tr>
         <th>id</th>

--- a/project/vision_backend/utils.py
+++ b/project/vision_backend/utils.py
@@ -1,4 +1,3 @@
-import boto
 import numpy as np
 from django.conf import settings
 
@@ -134,18 +133,3 @@ def labelset_mapper(labelmode, classids, source):
         raise Exception('labelmode {} not recognized'.format(labelmode))
 
     return classmap, classnames
-
-
-def get_total_messages_in_jobs_queue():
-    """
-    Returns number of jobs in the spacer jobs queue.
-    If there are, for some tests, it means we have to wait.
-    """
-    if not settings.DEFAULT_FILE_STORAGE == \
-            'lib.storage_backends.MediaStorageS3':
-        return 0
-    c = boto.sqs.connect_to_region('us-west-2')
-    queue = c.lookup('spacer_jobs')
-    attr = queue.get_attributes()
-    return int(attr['ApproximateNumberOfMessages']) + \
-        int(attr['ApproximateNumberOfMessagesNotVisible'])

--- a/project/vision_backend/views.py
+++ b/project/vision_backend/views.py
@@ -61,7 +61,6 @@ def backend_overview(request):
     i_act = i.active()
     i_qu = i.reserved()
     q_stats = {
-        'spacer': get_total_messages_in_jobs_queue(),
         'celery_scheduled': first_queue_length(i_sch),
         'celery_active': first_queue_length(i_act),
         'celery_queued': first_queue_length(i_qu),

--- a/project/vision_backend/views.py
+++ b/project/vision_backend/views.py
@@ -2,7 +2,7 @@ import csv
 import json
 
 import numpy as np
-from celery.task.control import inspect
+
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -46,25 +46,6 @@ def backend_overview(request):
             valid=True).count() / Source.objects.filter().count())
     }
 
-    def first_queue_length(inspect_category):
-        # For a given inspect category, there should be only one queue (e.g.
-        # 'celery@Ubuntu'). This function gets the length of that queue.
-        try:
-            first_queue = next(iter(inspect_category.values()))
-            return len(first_queue)
-        except AttributeError:
-            return 0
-
-    i = inspect()
-    i_sch = i.scheduled()
-    i_act = i.active()
-    i_qu = i.reserved()
-    q_stats = {
-        'celery_scheduled': first_queue_length(i_sch),
-        'celery_active': first_queue_length(i_act),
-        'celery_queued': first_queue_length(i_qu),
-    }
-
     laundry_list = []
     for source in Source.objects.filter().order_by('-id'):
         laundry_list.append(source_robot_status(source.id))
@@ -76,7 +57,6 @@ def backend_overview(request):
         'laundry_list': laundry_list,
         'img_stats': img_stats,
         'clf_stats': clf_stats,
-        'q_stats': q_stats
     })
 
 

--- a/project/vision_backend/views.py
+++ b/project/vision_backend/views.py
@@ -14,8 +14,7 @@ from lib.decorators import source_visibility_required
 from .confmatrix import ConfMatrix
 from .forms import TreshForm, CmTestForm
 from .models import Classifier
-from .utils import labelset_mapper, map_labels, \
-    get_total_messages_in_jobs_queue, get_alleviate
+from .utils import labelset_mapper, map_labels, get_alleviate
 
 
 @permission_required('is_superuser')


### PR DESCRIPTION
We can add the batch queue back in later. This will at least bring the page back up.