### PR TITLE
HTTPS in staging

### DIFF
--- a/project/accounts/models.py
+++ b/project/accounts/models.py
@@ -102,6 +102,7 @@ class Profile(models.Model):
                 hashlib.md5(email_byte_string).hexdigest())
         if self.avatar_file:
             # User provided an uploaded image
-            return posixpath.join(settings.MEDIA_URL, self.avatar_file.name)
+            # https://docs.djangoproject.com/en/dev/ref/models/fields/#django.db.models.fields.files.FieldFile.url
+            return self.avatar_file.url
         # Fall back to a random gravatar
         return self._get_gravatar_url(self.random_gravatar_hash)

--- a/project/config/settings/staging.py
+++ b/project/config/settings/staging.py
@@ -17,11 +17,3 @@ SITE_DOMAIN = 'ec2-35-162-62-60.us-west-2.compute.amazonaws.com'
 # Hosts/domain names that are valid for this site.
 # "*" matches anything, ".example.com" matches example.com and all subdomains
 ALLOWED_HOSTS = [SITE_DOMAIN]
-
-# Let's Encrypt doesn't accept amazonaws domain names, so we can't use
-# HTTPS on the staging server.
-# For this reason, it's highly recommended to use different admin passwords
-# from those used at the production site.
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
-SECURE_PROXY_SSL_HEADER = None


### PR DESCRIPTION
- Changed staging settings to assume HTTPS (by matching production on the relevant settings).
- Ensured user-uploaded avatars still show up as they should in staging. This change may or may not also be required in production now, in light of the latest software updates (particularly Django and django-storages).