### PR TITLE
Per-image calcification rate exports + rate table uploads

### DIFF
--- a/project/calcification/forms.py
+++ b/project/calcification/forms.py
@@ -1,0 +1,44 @@
+from django.forms import Form
+from django.forms.fields import ChoiceField, MultipleChoiceField
+from django.forms.widgets import CheckboxSelectMultiple
+
+from calcification.utils import get_default_calcify_tables
+
+
+def get_calcify_table_choices():
+    default_tables = get_default_calcify_tables()
+    choices = [
+        (table.pk, table.name)
+        for table in default_tables]
+
+    return choices
+
+
+class ExportCalcifyStatsForm(Form):
+    rate_table_id = ChoiceField(
+        label="Label rates to use",
+        choices=get_calcify_table_choices)
+
+    optional_columns = MultipleChoiceField(
+        widget=CheckboxSelectMultiple, required=False)
+
+    def __init__(self, source, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        # TODO: The best thing to do is to remove all possibility of
+        # initializing this form without a labelset, and then remove this
+        # conditional.
+        if source.labelset:
+            labelset_size = source.labelset.get_labels().count()
+        else:
+            labelset_size = 0
+
+        self.fields['optional_columns'].choices = (
+            ('per_label_mean',
+             "Per-label contributions to mean rate"
+             f" (adds {labelset_size} columns)"),
+            ('per_label_bounds',
+             "Per-label contributions to confidence bounds"
+             f" (adds {labelset_size * 2} columns)"),
+        )

--- a/project/calcification/forms.py
+++ b/project/calcification/forms.py
@@ -1,23 +1,33 @@
-from django.forms import Form
+from django.core.exceptions import ValidationError
+from django.forms import Form, ModelForm
 from django.forms.fields import ChoiceField, MultipleChoiceField
-from django.forms.widgets import CheckboxSelectMultiple
+from django.forms.widgets import CheckboxSelectMultiple, Textarea
 
-from calcification.utils import get_default_calcify_tables
+from upload.forms import CsvFileField
+from .models import CalcifyRateTable
+from .utils import get_default_calcify_tables
 
 
-def get_calcify_table_choices():
-    default_tables = get_default_calcify_tables()
+def get_calcify_table_choices(source):
+    # Source's tables
     choices = [
         (table.pk, table.name)
-        for table in default_tables]
+        for table in source.calcifyratetable_set.order_by('name')
+    ]
+
+    # Default tables
+    default_tables = get_default_calcify_tables()
+    choices.extend([
+        (table.pk, table.name)
+        for table in default_tables
+    ])
 
     return choices
 
 
 class ExportCalcifyStatsForm(Form):
     rate_table_id = ChoiceField(
-        label="Label rates to use",
-        choices=get_calcify_table_choices)
+        label="Label rates to use")
 
     optional_columns = MultipleChoiceField(
         widget=CheckboxSelectMultiple, required=False)
@@ -34,6 +44,9 @@ class ExportCalcifyStatsForm(Form):
         else:
             labelset_size = 0
 
+        self.fields['rate_table_id'].choices = \
+            get_calcify_table_choices(source)
+
         self.fields['optional_columns'].choices = (
             ('per_label_mean',
              "Per-label contributions to mean rate"
@@ -42,3 +55,33 @@ class ExportCalcifyStatsForm(Form):
              "Per-label contributions to confidence bounds"
              f" (adds {labelset_size * 2} columns)"),
         )
+
+
+class CalcifyRateTableForm(ModelForm):
+    csv_file = CsvFileField(label='CSV file')
+
+    class Meta:
+        model = CalcifyRateTable
+        fields = ['name', 'description']
+        widgets = {
+            'description': Textarea(),
+        }
+
+    def __init__(self, source, *args, **kwargs):
+        self.source = source
+        super().__init__(*args, **kwargs)
+
+    def clean_name(self):
+        """
+        Check for uniqueness within the source. The ModelForm doesn't
+        validate this automatically because the source isn't a field in the
+        form.
+        """
+        name = self.cleaned_data['name']
+        try:
+            CalcifyRateTable.objects.get(source=self.source, name=name)
+            raise ValidationError(
+                "This source already has a rate table with the same name.")
+        except CalcifyRateTable.DoesNotExist:
+            # This name isn't taken yet, so it's valid.
+            return name

--- a/project/calcification/static/js/CalcifyTablesHelper.js
+++ b/project/calcification/static/js/CalcifyTablesHelper.js
@@ -1,0 +1,141 @@
+class CalcifyTablesHelper {
+
+    constructor(canManageTables) {
+
+        // Show calcify table management dialog when the appropriate button
+        // is clicked.
+        document.getElementById('manage-calcify-tables-button')
+                .addEventListener('click', function () {
+            $('#manage-calcify-tables').dialog({
+                width: 800,
+                height: 500,
+                modal: true,
+                title: "Calcification rate tables"
+            });
+        });
+
+        if (!canManageTables) {
+            return;
+        }
+        // All of the below assumes permission to upload/delete tables.
+
+        this.uploadFormE = document.getElementById(
+            'new-rate-table-form');
+        this.uploadFormStatusE = document.getElementById(
+            'new-rate-table-form-status');
+        this.uploadSubmitEnabled = true;
+
+        // Show calcify table upload dialog when the appropriate button
+        // is clicked.
+        document.getElementById('new-rate-table-form-show-button')
+                .addEventListener('click', function () {
+            $('#new-rate-table-form-popup').dialog({
+                width: 500,
+                height: 300,
+                modal: true,
+                title: "Upload a rate table",
+                // This option adds an extra CSS class to the dialog.
+                // https://api.jqueryui.com/dialog/#option-classes
+                classes: {
+                    'ui-dialog': 'ui-dialog-form'
+                }
+            });
+        });
+
+        // Upload form submit handler.
+        // bind() ensures `this` refers to our class instance, not the element.
+        // https://stackoverflow.com/a/43727582
+        this.uploadFormE.onsubmit = this.uploadSubmit.bind(this);
+
+        // Delete forms' submit handlers.
+        this.setDeleteFormHandlers();
+    }
+
+    uploadSubmit(event) {
+        // Don't let the form do a non-Ajax submit
+        // (browsers' default submit behavior).
+        event.preventDefault();
+
+        if (this.uploadSubmitEnabled) {
+            let url = this.uploadFormE.action;
+            let formData = new FormData(this.uploadFormE);
+
+            util.fetch(
+                url, {method: 'POST', body: formData},
+                this.uploadHandleResponse.bind(this));
+
+            this.uploadFormStatusE.textContent = "Submitting...";
+            this.uploadSubmitEnabled = false;
+        }
+    }
+
+    uploadHandleResponse(response) {
+        this.uploadFormStatusE.textContent = "";
+        this.uploadSubmitEnabled = true;
+
+        if (response['error']) {
+            // There was an error processing the form submission.
+            this.uploadFormStatusE.textContent = response['error'];
+            return;
+        }
+
+        this.refreshTableChoices(response);
+
+        this.uploadFormStatusE.textContent = "Table successfully uploaded.";
+
+        // Clear the form fields in case the user wants to upload another table
+        let formFields = this.uploadFormE.querySelectorAll(
+            'input[type="text"], input[type="file"], textarea');
+        formFields.forEach(function(field) {
+            field.value = '';
+        });
+    }
+
+    deleteSubmit(form, event) {
+        // Don't let the form do a non-Ajax submit
+        // (browsers' default submit behavior).
+        event.preventDefault();
+
+        let confirmResult = window.confirm(
+            "Are you sure you want to delete this rate table?");
+        if (!confirmResult) {
+            return;
+        }
+
+        let url = form.action;
+        // Form data includes the CSRF token, which we need.
+        let formData = new FormData(form);
+
+        util.fetch(
+            url, {method: 'POST', body: formData},
+            this.refreshTableChoices.bind(this));
+    }
+
+    /*
+    This should be called when handling a response which changes the
+    source's available tables. So, a response from upload or delete.
+    `response` is the response JSON from either of those views.
+    */
+    refreshTableChoices(response) {
+        // Replace HTML for the table dropdown.
+        let element = document.getElementById('id_rate_table_id');
+        element.insertAdjacentHTML('afterend', response['tableDropdownHtml']);
+        element.remove();
+
+        // Replace HTML for the grid of tables element.
+        element = document.getElementById('table-of-calcify-tables');
+        element.insertAdjacentHTML('afterend', response['gridOfTablesHtml']);
+        element.remove();
+
+        // Now that the delete forms have been replaced, attach
+        // the delete handlers to the new forms.
+        this.setDeleteFormHandlers();
+    }
+
+    setDeleteFormHandlers() {
+        let deleteForms = document.querySelectorAll('form.rate-table-delete');
+        deleteForms.forEach((deleteForm) => {
+            deleteForm.onsubmit = this.deleteSubmit.bind(this, deleteForm);
+        });
+    }
+}

--- a/project/calcification/templates/calcification/grid_of_tables.html
+++ b/project/calcification/templates/calcification/grid_of_tables.html
@@ -1,0 +1,43 @@
+<table class="detail_table" id="table-of-calcify-tables">
+  <tr>
+    <th>Name</th>
+    <th>Description</th>
+    <th></th>
+  </tr>
+
+  {% for rate_table in source_calcification_tables %}
+    <tr>
+      <td>{{ rate_table.name }}</td>
+      <td class="description">{{ rate_table.description }}</td>
+      <td class="actions">
+        <form action="{% url 'calcification:rate_table_download' rate_table.pk %}" method="get">
+          <button>Download CSV</button>
+        </form>
+
+        {% if can_manage_calcification_tables %}
+          <form action="{% url 'calcification:rate_table_delete_ajax' rate_table.pk %}" method="post" class="rate-table-delete">
+            {% csrf_token %}
+            <button>Delete</button>
+          </form>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+
+  {% for rate_table in default_calcification_tables %}
+    <tr>
+      <td>{{ rate_table.name }}</td>
+      <td class="description"></td>
+      <td class="actions">
+        <form action="{% url 'calcification:rate_table_download' rate_table.pk %}" method="get">
+          <input type="hidden" name="source_id" value="{{ source.pk }}" />
+          <button>Download CSV (labelset entries only)</button>
+        </form>
+
+        <form action="{% url 'calcification:rate_table_download' rate_table.pk %}" method="get">
+          <button>Download CSV (full)</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+</table>

--- a/project/calcification/templates/calcification/help_default_rates.html
+++ b/project/calcification/templates/calcification/help_default_rates.html
@@ -8,8 +8,10 @@
   {# Links to default rate tables #}
   You can view all the rates CoralNet provides in CSV format here:
 
-  {% for region, table_id in calcification_table_ids.items %}
-    <a href="{% url 'calcification:rate_table_download' table_id %}">{{ region }}</a>
+  {% for table in calcification_tables %}
+    <a href="{% url 'calcification:rate_table_download' table.pk %}">
+      {{ table.region }}
+    </a>
 
     {% if not forloop.last %}
       ,

--- a/project/calcification/templates/calcification/help_default_rates.html
+++ b/project/calcification/templates/calcification/help_default_rates.html
@@ -1,13 +1,11 @@
 <div class="article-body">
 
 
-<p>Rates are in units of kg CaCO<sub>3</sub> m<sup>-2</sup> yr<sup>-1</sup>. A rate above 0 means that this label's presence contributes to positive carbonate production (i.e., calcification). A rate below 0 means that this label's presence contributes to negative carbonate production (i.e., bioerosion).</p>
-
-<p>Note that only some of CoralNet's labels have rates provided.
-
-  {# Links to default rate tables #}
+<p>
+  Note that only some of CoralNet's labels have rates provided, and many of those labels only have rates provided in one region.
   You can view all the rates CoralNet provides in CSV format here:
 
+  {# Links to default rate tables #}
   {% for table in calcification_tables %}
     <a href="{% url 'calcification:rate_table_download' table.pk %}">
       {{ table.region }}
@@ -19,9 +17,7 @@
   {% endfor %}
 </p>
 
-<p>CoralNet's calcification rates are derived from <a href="http://geography.exeter.ac.uk/reefbudget/" target="_blank">ReefBudget</a>'s data.</p>
+{% include 'calcification/help_rates.html' %}
 
-
-{# TODO: Link to Zenodo repo with rate table change history #}
 
 </div>

--- a/project/calcification/templates/calcification/help_rates.html
+++ b/project/calcification/templates/calcification/help_rates.html
@@ -1,0 +1,5 @@
+<p>Rates are in units of kg CaCO<sub>3</sub> m<sup>-2</sup> yr<sup>-1</sup>. A rate above 0 means that the label's presence contributes to positive carbonate production (i.e., calcification). A rate below 0 means that the label's presence contributes to negative carbonate production (i.e., bioerosion).</p>
+
+<p>CoralNet's calcification rates are derived from <a href="http://geography.exeter.ac.uk/reefbudget/" target="_blank">ReefBudget</a>'s data.</p>
+
+{# TODO: Link to Zenodo repo with rate table change history #}

--- a/project/calcification/templates/calcification/manage_tables.html
+++ b/project/calcification/templates/calcification/manage_tables.html
@@ -1,16 +1,47 @@
-<table class="detail_table">
-  {% for rate_table in default_calcification_tables %}
-    <tr>
-      <td>{{ rate_table.name }}</td>
-      <td>
-        <form action="{% url 'calcification:rate_table_download' rate_table.pk %}" method="get">
-          <button>Download CSV</button>
-        </form>
-      </td>
-    </tr>
-  {% endfor %}
-</table>
+{% include 'calcification/grid_of_tables.html' with default_calcification_tables=default_calcification_tables source_calcification_tables=source_calcification_tables %}
+
+{% if can_manage_calcification_tables %}
+  <button id="new-rate-table-form-show-button">+ Upload a new table</button>
+{% endif %}
 
 <p>If a table does not define a rate for a particular label, CoralNet's computation assumes a rate of 0 for that label.</p>
 
 {% include 'calcification/help_rates.html' %}
+
+
+{# Modal dialog contents live in this hidden element until they're needed. #}
+<div hidden>
+  <div id="new-rate-table-form-popup">
+    <div class="line">
+      If you want to create a rate table for this source, we recommend you start off with a template table by clicking the "Download CSV (labelset entries only)" button next to one of the default tables.
+    </div>
+
+    <form id="new-rate-table-form"
+      action="{% url 'calcification:rate_table_upload_ajax' source.pk %}"
+      method="post" enctype="multipart/form-data">
+      {% csrf_token %}
+
+      {% for field in calcify_table_form %}
+        <div class="line">
+          {% if field.field.required %}
+            <span style="color:red;">
+              *
+            </span>
+          {% endif %}
+
+          {{ field.label }}: {{ field }}
+        </div>
+
+        {% if field.help_text %}
+          <div class="helptext_small">
+            {{ field.help_text|safe|linebreaksbr }}</div>
+        {% endif %}
+      {% endfor %}
+
+      {# This status element is for error messages, etc. #}
+      <div class="line" id="new-rate-table-form-status" style="font-weight: bold;"></div>
+
+      <input type="submit" value="Upload Table" />
+    </form>
+  </div>
+</div>

--- a/project/calcification/templates/calcification/manage_tables.html
+++ b/project/calcification/templates/calcification/manage_tables.html
@@ -1,0 +1,16 @@
+<table class="detail_table">
+  {% for rate_table in default_calcification_tables %}
+    <tr>
+      <td>{{ rate_table.name }}</td>
+      <td>
+        <form action="{% url 'calcification:rate_table_download' rate_table.pk %}" method="get">
+          <button>Download CSV</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+</table>
+
+<p>If a table does not define a rate for a particular label, CoralNet's computation assumes a rate of 0 for that label.</p>
+
+{% include 'calcification/help_rates.html' %}

--- a/project/calcification/tests/test_delete_table.py
+++ b/project/calcification/tests/test_delete_table.py
@@ -1,0 +1,187 @@
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from lib.tests.utils import BasePermissionTest, ClientTest
+from ..models import CalcifyRateTable
+from .utils import (
+    create_default_calcify_table, create_source_calcify_table,
+    grid_of_tables_html_to_tuples)
+
+
+class PermissionTest(BasePermissionTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        # Make the action form show on Browse Images
+        cls.upload_image(cls.user, cls.source)
+
+        create_default_calcify_table('Atlantic', dict())
+
+    def test_calcify_table_delete_in_private_source(self):
+        deletion_urls = []
+        for i in range(5):
+            table = create_source_calcify_table(
+                self.source, dict(), name=f"Table {i}")
+            deletion_urls.append(reverse(
+                'calcification:rate_table_delete_ajax', args=[table.pk]))
+
+        # Accessing the view. Use different images so we can re-test after a
+        # successful delete.
+        self.source_to_private()
+        self.assertPermissionDeniedJson(deletion_urls[0], None, post_data={})
+        self.assertPermissionDeniedJson(
+            deletion_urls[1], self.user_outsider, post_data={})
+        self.assertPermissionDeniedJson(
+            deletion_urls[2], self.user_viewer, post_data={})
+        self.assertPermissionGrantedJson(
+            deletion_urls[3], self.user_editor, post_data={})
+        self.assertPermissionGrantedJson(
+            deletion_urls[4], self.user_admin, post_data={})
+
+    def test_calcify_table_delete_in_public_source(self):
+        deletion_urls = []
+        for i in range(5):
+            table = create_source_calcify_table(
+                self.source, dict(), name=f"Table {i}")
+            deletion_urls.append(reverse(
+                'calcification:rate_table_delete_ajax', args=[table.pk]))
+
+        self.source_to_public()
+        self.assertPermissionDeniedJson(deletion_urls[0], None, post_data={})
+        self.assertPermissionDeniedJson(
+            deletion_urls[1], self.user_outsider, post_data={})
+        self.assertPermissionDeniedJson(
+            deletion_urls[2], self.user_viewer, post_data={})
+        self.assertPermissionGrantedJson(
+            deletion_urls[3], self.user_editor, post_data={})
+        self.assertPermissionGrantedJson(
+            deletion_urls[4], self.user_admin, post_data={})
+
+    def test_delete_button_requires_edit_perm(self):
+        # Ensure there's at least one source table
+        create_source_calcify_table(self.source, dict())
+
+        url = reverse('browse_images', args=[self.source.pk])
+
+        def button_is_present():
+            response = self.client.get(url, follow=True)
+            response_soup = BeautifulSoup(response.content, 'html.parser')
+
+            delete_forms = response_soup.select('form.rate-table-delete')
+            return bool(delete_forms)
+
+        self.client.force_login(self.user_editor)
+        self.assertTrue(button_is_present())
+        self.client.force_login(self.user_viewer)
+        self.assertFalse(button_is_present())
+
+
+class TableDeleteTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        # Make the action form show on Browse Images
+        cls.upload_image(cls.user, cls.source)
+
+        cls.default_atlantic = create_default_calcify_table(
+            'Atlantic', dict(),
+            name="Default Atlantic rates")
+        cls.default_indo_pacific = create_default_calcify_table(
+            'Indo-Pacific', dict(),
+            name="Default Indo-Pacific rates")
+
+    def test_success(self):
+        table = create_source_calcify_table(self.source, dict())
+        table_id = table.pk
+
+        self.client.force_login(self.user)
+        response = self.client.post(reverse(
+            'calcification:rate_table_delete_ajax', args=[table_id]))
+
+        # Table shouldn't be in the DB anymore
+        self.assertRaises(
+            CalcifyRateTable.DoesNotExist,
+            CalcifyRateTable.objects.get,
+            pk=table_id)
+
+        # Check response content
+        self.assertStatusOK(response)
+        response_json = response.json()
+        self.assertHTMLEqual(
+            response_json['tableDropdownHtml'],
+            '<select id="id_rate_table_id" name="rate_table_id">'
+            f'  <option value="{self.default_atlantic.pk}">'
+            f'    {self.default_atlantic.name}</option>'
+            f'  <option value="{self.default_indo_pacific.pk}">'
+            f'    {self.default_indo_pacific.name}</option>'
+            '</select>')
+        self.assertListEqual(
+            grid_of_tables_html_to_tuples(
+                response_json['gridOfTablesHtml']),
+            [
+                ("Default Atlantic rates", "",
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_atlantic.pk]),
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_atlantic.pk])),
+                ("Default Indo-Pacific rates", "",
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_indo_pacific.pk]),
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_indo_pacific.pk])),
+            ]
+        )
+
+    def test_nonexistent_table_id(self):
+        """
+        Trying to delete a nonexistent table ID should obviously fail, and
+        should also show the permission error in order to obfuscate which
+        IDs actually exist.
+        """
+        table = create_source_calcify_table(self.source, dict())
+        table_id = table.pk
+
+        self.client.force_login(self.user)
+        # Delete
+        response = self.client.post(reverse(
+            'calcification:rate_table_delete_ajax', args=[table_id]))
+        # Just for good measure, ensure this succeeded
+        self.assertNotIn('error', response.json())
+        # Attempt to delete the same ID
+        response = self.client.post(reverse(
+            'calcification:rate_table_delete_ajax', args=[table_id]))
+
+        self.assertEqual(
+            response.json()['error'],
+            f"You don't have permission to delete table of ID {table_id}.")
+
+    def test_default_table(self):
+        """Can't delete default tables using the delete view."""
+        table_id = self.default_atlantic.pk
+
+        self.client.force_login(self.user)
+        response = self.client.post(reverse(
+            'calcification:rate_table_delete_ajax', args=[table_id]))
+
+        # Table should still exist (this should not raise DoesNotExist)
+        CalcifyRateTable.objects.get(pk=table_id)
+
+        self.assertEqual(
+            response.json()['error'],
+            f"You don't have permission to delete table of ID {table_id}.")

--- a/project/calcification/tests/test_download.py
+++ b/project/calcification/tests/test_download.py
@@ -1,7 +1,51 @@
 from django.urls import reverse
 
 from export.tests.utils import BaseExportTest
-from ..models import CalcifyRateTable
+from lib.tests.utils import BasePermissionTest
+from .utils import create_default_calcify_table, create_source_calcify_table
+
+
+class PermissionTest(BasePermissionTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+    def test_default_table_download(self):
+        table = create_default_calcify_table('Atlantic', dict())
+        url = reverse(
+            'calcification:rate_table_download', args=[table.pk])
+
+        self.assertPermissionLevel(
+            url, self.SIGNED_OUT, content_type='text/csv')
+
+    def test_source_table_download(self):
+        table = create_source_calcify_table(self.source, dict())
+        url = reverse(
+            'calcification:rate_table_download', args=[table.pk])
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SOURCE_VIEW, content_type='text/csv')
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SIGNED_OUT, content_type='text/csv')
+
+    def test_default_table_download_with_source_param(self):
+        table = create_default_calcify_table('Atlantic', dict())
+        url = self.make_url_with_params(
+            reverse('calcification:rate_table_download', args=[table.pk]),
+            dict(source_id=self.source.pk))
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SOURCE_VIEW, content_type='text/csv')
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SIGNED_OUT, content_type='text/csv')
 
 
 class RateTableDownloadTest(BaseExportTest):
@@ -13,17 +57,22 @@ class RateTableDownloadTest(BaseExportTest):
         cls.user = cls.create_user()
         cls.labels = cls.create_labels(cls.user, ['A', 'B', 'C'], 'GroupA')
 
-    def test_basic(self):
-        table = CalcifyRateTable(
-            name="Table Name", description="Desc",
-            rates_json={
+        cls.source = cls.create_source(cls.user)
+        cls.create_labelset(
+            cls.user, cls.source, cls.labels.filter(name__in=['B', 'C']))
+
+    def test_default_table(self):
+        """Download a default rate table."""
+        table = create_default_calcify_table(
+            'Atlantic',
+            {
                 str(self.labels.get(name='A').pk): dict(
                     mean='2.0', lower_bound='1.0', upper_bound='3.0'),
                 str(self.labels.get(name='B').pk): dict(
                     mean='-2.0', lower_bound='-3.0', upper_bound='-1.0'),
             },
-            source=None)
-        table.save()
+            name="Table Name",
+        )
 
         response = self.client.get(
             reverse('calcification:rate_table_download', args=[table.pk]))
@@ -40,12 +89,62 @@ class RateTableDownloadTest(BaseExportTest):
             ('Content-Disposition', 'attachment;filename="Table Name.csv"'),
             msg="CSV filename should be as expected")
 
+    def test_source_table(self):
+        """Download a table belonging to a source."""
+        table = create_source_calcify_table(
+            self.source,
+            {
+                str(self.labels.get(name='B').pk): dict(
+                    mean='2.0', lower_bound='1.0', upper_bound='3.0'),
+                str(self.labels.get(name='C').pk): dict(
+                    mean='-2.0', lower_bound='-3.0', upper_bound='-1.0'),
+            },
+        )
+
+        response = self.client.get(
+            reverse('calcification:rate_table_download', args=[table.pk]))
+
+        expected_lines = [
+            'Label,Mean rate,Lower bound,Upper bound',
+            'B,2.0,1.0,3.0',
+            'C,-2.0,-3.0,-1.0',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_default_table_filtered_to_source_labelset(self):
+        """
+        Download a default table while specifying a source's labelset to
+        filter the entries on.
+        """
+        table = create_default_calcify_table(
+            'Atlantic',
+            {
+                str(self.labels.get(name='A').pk): dict(
+                    mean='2.0', lower_bound='1.0', upper_bound='3.0'),
+                str(self.labels.get(name='B').pk): dict(
+                    mean='-2.0', lower_bound='-3.0', upper_bound='-1.0'),
+            },
+            name="Table Name",
+        )
+
+        response = self.client.get(
+            reverse('calcification:rate_table_download', args=[table.pk]),
+            data=dict(source_id=self.source.pk),
+        )
+
+        expected_lines = [
+            'Label,Mean rate,Lower bound,Upper bound',
+            # A isn't in the labelset
+            # B is in the labelset and in the table
+            'B,-2.0,-3.0,-1.0',
+            # C isn't in the table
+            'C,0.0,0.0,0.0',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
     def test_table_name_with_non_filename_chars(self):
-        table = CalcifyRateTable(
-            name="<Table/Name?>", description="Desc",
-            rates_json={},
-            source=None)
-        table.save()
+        table = create_default_calcify_table(
+            'Atlantic', {}, name="<Table/Name?>")
 
         response = self.client.get(
             reverse('calcification:rate_table_download', args=[table.pk]))

--- a/project/calcification/tests/test_export_stats.py
+++ b/project/calcification/tests/test_export_stats.py
@@ -1,0 +1,488 @@
+from django.urls import reverse
+
+from export.tests.utils import BaseExportTest
+from lib.tests.utils import BasePermissionTest, ClientTest
+from .utils import create_default_calcify_table
+
+
+class PermissionTest(BasePermissionTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        cls.calcify_table = create_default_calcify_table('Atlantic', dict())
+
+    def test_calcify_stats_export(self):
+        get_params = dict(rate_table_id=self.calcify_table.pk)
+        url = self.make_url_with_params(
+            reverse('calcification:stats_export', args=[self.source.pk]),
+            get_params)
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SOURCE_VIEW, content_type='text/csv')
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SIGNED_IN, content_type='text/csv',
+            deny_type=self.REQUIRE_LOGIN)
+
+
+class BaseCalcifyStatsExportTest(BaseExportTest):
+    """Subclasses must define self.client and self.source."""
+
+    def export_calcify_stats(self, data):
+        """GET the export view and return the response."""
+        self.client.force_login(self.user)
+        return self.client.get(
+            reverse('calcification:stats_export', args=[self.source.pk]),
+            data, follow=True)
+
+
+class ExportTest(BaseCalcifyStatsExportTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(
+            cls.user, name="Test source", simple_number_of_points=5)
+
+        cls.labels = cls.create_labels(
+            cls.user, ['A', 'B', 'C'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+        cls.label_pks = {label.name: label.pk for label in cls.labels}
+
+    def test_filename_and_content_type(self):
+        calcify_table = create_default_calcify_table('Atlantic', {})
+        response = self.export_calcify_stats(
+            dict(rate_table_id=calcify_table.pk))
+
+        # TODO: Also test for the correct date in the filename, perhaps
+        # allowing for being 1 day off so the test is robust
+        self.assertTrue(
+            response['content-disposition'].startswith(
+                'attachment;filename="Test source - Calcification rates - '),
+            msg="Filename should have the source name as expected")
+        self.assertTrue(
+            response['content-disposition'].endswith('.csv"'))
+
+        self.assertTrue(
+            response['content-type'].startswith('text/csv'),
+            msg="Content type should be CSV")
+
+    def test_basic_contents(self):
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'A', 3: 'A', 4: 'A', 5: 'A'})
+
+        img2 = self.upload_image(
+            self.user, self.source, dict(filename='2.jpg'))
+        self.add_annotations(self.user, img2, {
+            1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
+
+        calcify_table = create_default_calcify_table(
+            'Atlantic',
+            {
+                self.label_pks['A']: dict(
+                    mean=4.0, lower_bound=3.2, upper_bound=4.8),
+                self.label_pks['B']: dict(
+                    mean=1.0, lower_bound=0.8, upper_bound=1.3),
+            },
+        )
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=calcify_table.pk))
+
+        # Column headers, image IDs/names, calculations, and decimal places
+        # should be as expected; and should work with multiple images
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound',
+            f'{img1.pk},1.jpg,4.000,3.200,4.800',
+            # 4.0*0.6 + 1.0*0.4
+            # 3.2*0.6 + 0.8*0.4
+            # 4.8*0.6 + 1.3*0.4
+            f'{img2.pk},2.jpg,2.800,2.240,3.400',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_zero_for_undefined_rate(self):
+        """If a label has no rate defined for it, should assume a 0 rate."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
+
+        calcify_table = create_default_calcify_table(
+            'Atlantic',
+            {
+                self.label_pks['A']: dict(
+                    mean=4.0, lower_bound=3.2, upper_bound=4.8),
+                # Nothing for B
+            },
+        )
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=calcify_table.pk))
+
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound',
+            # 4.0*0.6
+            # 3.2*0.6
+            # 4.8*0.6
+            f'{img1.pk},1.jpg,2.400,1.920,2.880',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_different_tables(self):
+        """Rate table choice should be respected in the export."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'B', 3: 'C', 4: 'B', 5: 'C'})
+
+        calcify_table_1 = create_default_calcify_table(
+            'Atlantic',
+            {
+                self.label_pks['A']: dict(
+                    mean=4.0, lower_bound=3.2, upper_bound=4.8),
+                self.label_pks['B']: dict(
+                    mean=1.0, lower_bound=0.8, upper_bound=1.3),
+            },
+        )
+        calcify_table_2 = create_default_calcify_table(
+            'Indo-Pacific',
+            {
+                self.label_pks['B']: dict(
+                    mean=1.5, lower_bound=1.0, upper_bound=2.0),
+                self.label_pks['C']: dict(
+                    mean=-3.0, lower_bound=-4.2, upper_bound=-2.2),
+            },
+        )
+
+        # Table 1
+        response = self.export_calcify_stats(
+            dict(rate_table_id=calcify_table_1.pk))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound',
+            # 4.0*0.2 + 1.0*0.4
+            # 3.2*0.2 + 0.8*0.4
+            # 4.8*0.2 + 1.3*0.4
+            f'{img1.pk},1.jpg,1.200,0.960,1.480',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+        # Table 2
+        response = self.export_calcify_stats(
+            dict(rate_table_id=calcify_table_2.pk))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound',
+            # 1.5*0.4 + -3.0*0.4
+            # 1.0*0.4 + -4.2*0.4
+            # 2.0*0.4 + -2.2*0.4
+            f'{img1.pk},1.jpg,-0.600,-1.280,-0.080',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_optional_columns_contributions(self):
+        """Test the optional mean and bounds contributions columns."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
+
+        calcify_table = create_default_calcify_table(
+            'Atlantic',
+            {
+                self.label_pks['A']: dict(
+                    mean=4.0, lower_bound=3.2, upper_bound=4.8),
+                self.label_pks['B']: dict(
+                    mean=1.0, lower_bound=0.8, upper_bound=1.3),
+            },
+        )
+
+        # Mean only
+        response = self.export_calcify_stats(
+            dict(
+                rate_table_id=calcify_table.pk,
+                optional_columns='per_label_mean'))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound,'
+            'A M,B M,C M',
+            # 4.0*0.6 + 1.0*0.4
+            # 3.2*0.6 + 0.8*0.4
+            # 4.8*0.6 + 1.3*0.4
+            f'{img1.pk},1.jpg,2.800,2.240,3.400,'
+            # 4.0*0.6
+            # 1.0*0.4
+            # 0
+            '2.400,0.400,0.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+        # Bounds only
+        response = self.export_calcify_stats(
+            dict(
+                rate_table_id=calcify_table.pk,
+                optional_columns='per_label_bounds'))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound,'
+            'A LB,B LB,C LB,A UB,B UB,C UB',
+            f'{img1.pk},1.jpg,2.800,2.240,3.400,'
+            # 3.2*0.6
+            # 0.8*0.4
+            # 0
+            # 4.8*0.6
+            # 1.3*0.4
+            # 0
+            '1.920,0.320,0.000,2.880,0.520,0.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+        # Mean and bounds
+        response = self.export_calcify_stats(
+            dict(
+                rate_table_id=calcify_table.pk,
+                optional_columns=['per_label_mean', 'per_label_bounds']))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound,'
+            'A M,B M,C M,A LB,B LB,C LB,A UB,B UB,C UB',
+            f'{img1.pk},1.jpg,2.800,2.240,3.400,'
+            '2.400,0.400,0.000,1.920,0.320,0.000,2.880,0.520,0.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_no_negative_zero(self):
+        """
+        Should not show -0.000 for zero contributions on labels with
+        negative rates.
+        """
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'A', 3: 'A', 4: 'A', 5: 'A'})
+
+        calcify_table = create_default_calcify_table(
+            'Atlantic',
+            {
+                self.label_pks['A']: dict(
+                    mean=4.0, lower_bound=3.2, upper_bound=4.8),
+                self.label_pks['C']: dict(
+                    mean=-3.0, lower_bound=-4.2, upper_bound=-2.2),
+            },
+        )
+
+        # Mean only
+        response = self.export_calcify_stats(
+            dict(
+                rate_table_id=calcify_table.pk,
+                optional_columns=['per_label_mean', 'per_label_bounds']))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound,'
+            'A M,B M,C M,A LB,B LB,C LB,A UB,B UB,C UB',
+            f'{img1.pk},1.jpg,4.000,3.200,4.800,'
+            # Contributions from C in particular should be 0.000, not -0.000
+            '4.000,0.000,0.000,3.200,0.000,0.000,4.800,0.000,0.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_nonexistent_table_id(self):
+        """
+        Nonexistent table ID should return to Browse with an error message at
+        the top.
+        """
+        # No tables should have been created yet, so this ID should be
+        # nonexistent.
+        response = self.export_calcify_stats(
+            dict(rate_table_id=1))
+
+        # Display an error in HTML instead of serving CSV.
+        self.assertTrue(response['content-type'].startswith('text/html'))
+        # It's not the most intuitive error message, but it shouldn't be a
+        # common error case either (e.g. people typing URLs with GET params
+        # manually).
+        self.assertContains(
+            response,
+            "Label rates to use: Select a valid choice."
+            " 1 is not one of the available choices.")
+
+    # TODO: Test ID of a table belonging to another source.
+
+
+class ImageSetTest(BaseCalcifyStatsExportTest):
+    """
+    Test calcification stats export to CSV for different kinds of image
+    subsets.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(
+            cls.user, simple_number_of_points=5)
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        cls.calcify_table = create_default_calcify_table('Atlantic', dict())
+
+    def assert_csv_image_set(self, actual_csv_content, expected_images):
+        # Convert from bytes to Unicode if necessary.
+        if isinstance(actual_csv_content, bytes):
+            actual_csv_content = actual_csv_content.decode()
+
+        # The Python csv module uses \r\n by default (as part of the Excel
+        # dialect). Due to the way we compare line by line, splitting on
+        # \n would mess up the comparison, so we use split() instead of
+        # splitlines().
+        actual_lines = actual_csv_content.split('\r\n')
+        # Since we're not using splitlines(), we have to deal with ending
+        # newlines manually.
+        if actual_lines[-1] == "":
+            actual_lines.pop()
+
+        # expected_images should be an iterable of Image objects. We'll check
+        # that expected_images are exactly the images represented in line 2
+        # of the CSV onward.
+        self.assertEqual(
+            len(expected_images), len(actual_lines)-1,
+            msg="Number of images in the CSV should be as expected")
+
+        for line, image in zip(actual_lines[1:], expected_images):
+            self.assertTrue(
+                line.startswith(f'{image.pk},{image.metadata.name},'),
+                msg="CSV line should have the expected image ID and name")
+
+    def test_all_images_single(self):
+        """Export for 1 out of 1 images."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=self.calcify_table.pk))
+        self.assert_csv_image_set(response.content, [img1])
+
+    def test_all_images_multiple(self):
+        """Export for n out of n images."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        img2 = self.upload_image(
+            self.user, self.source, dict(filename='2.jpg'))
+        img3 = self.upload_image(
+            self.user, self.source, dict(filename='3.jpg'))
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=self.calcify_table.pk))
+        self.assert_csv_image_set(response.content, [img1, img2, img3])
+
+    def test_image_subset_by_metadata(self):
+        """Export for some, but not all, images."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        img2 = self.upload_image(
+            self.user, self.source, dict(filename='2.jpg'))
+        img3 = self.upload_image(
+            self.user, self.source, dict(filename='3.jpg'))
+        img1.metadata.aux1 = 'X'
+        img1.metadata.save()
+        img2.metadata.aux1 = 'Y'
+        img2.metadata.save()
+        img3.metadata.aux1 = 'X'
+        img3.metadata.save()
+
+        data = self.default_search_params.copy()
+        data['aux1'] = 'X'
+        data['rate_table_id'] = self.calcify_table.pk
+        response = self.export_calcify_stats(data)
+        self.assert_csv_image_set(response.content, [img1, img3])
+
+    def test_image_empty_set(self):
+        """Export for 0 images."""
+        self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+
+        data = self.default_search_params.copy()
+        data['image_name'] = '5.jpg'
+        data['rate_table_id'] = self.calcify_table.pk
+        response = self.export_calcify_stats(data)
+        self.assert_csv_image_set(response.content, [])
+
+    def test_invalid_image_set_params(self):
+        self.upload_image(self.user, self.source)
+
+        data = self.default_search_params.copy()
+        data['photo_date_0'] = 'abc'
+        data['rate_table_id'] = self.calcify_table.pk
+        response = self.export_calcify_stats(data)
+
+        # Display an error in HTML instead of serving CSV.
+        self.assertTrue(response['content-type'].startswith('text/html'))
+        self.assertContains(response, "Image-search parameters were invalid.")
+
+    def test_dont_get_other_sources_images(self):
+        """Don't export for other sources' images."""
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+
+        source2 = self.create_source(self.user, simple_number_of_points=5)
+        self.create_labelset(self.user, source2, self.labels)
+        self.upload_image(self.user, source2, dict(filename='2.jpg'))
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=self.calcify_table.pk))
+        # Should have image 1, but not 2
+        self.assert_csv_image_set(response.content, [img1])
+
+
+class UnicodeTest(BaseCalcifyStatsExportTest):
+    """Test that non-ASCII characters don't cause problems."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(
+            cls.user, simple_number_of_points=5)
+
+        # No Unicode to test on labels, since the export uses the label name,
+        # which is ASCII only.
+        labels = cls.create_labels(cls.user, ['A'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, labels)
+
+        cls.calcify_table = create_default_calcify_table('Atlantic', dict())
+
+    def test(self):
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='あ.jpg'))
+
+        response = self.export_calcify_stats(
+            dict(rate_table_id=self.calcify_table.pk))
+        expected_lines = [
+            'Image ID,Image name,Mean rate,Lower bound,Upper bound',
+            f'{img1.pk},あ.jpg,0.000,0.000,0.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+
+class BrowseActionsTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        group1_labels = cls.create_labels(
+            cls.user, ['A', 'B', 'C', 'D', 'E', 'F'], 'Group1')
+        cls.create_labels(cls.user, ['G', 'H'], 'Group2')
+
+        # Create a labelset with only a subset of the labels (6 of 8)
+        cls.create_labelset(cls.user, cls.source, group1_labels)
+
+    # TODO

--- a/project/calcification/tests/test_upload_table.py
+++ b/project/calcification/tests/test_upload_table.py
@@ -1,0 +1,358 @@
+from io import StringIO
+
+from bs4 import BeautifulSoup
+from django.core.files.base import ContentFile
+from django.urls import reverse
+
+from lib.tests.utils import (
+    BasePermissionTest, ClientTest, sample_image_as_file)
+from ..models import CalcifyRateTable
+from .utils import (
+    create_default_calcify_table, grid_of_tables_html_to_tuples)
+
+
+class PermissionTest(BasePermissionTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        # Make the action form show on Browse Images
+        cls.upload_image(cls.user, cls.source)
+
+        create_default_calcify_table('Atlantic', dict())
+
+    def test_calcify_table_upload(self):
+        url = reverse(
+            'calcification:rate_table_upload_ajax', args=[self.source.pk])
+
+        self.source_to_private()
+        self.assertPermissionLevel(
+            url, self.SOURCE_EDIT, is_json=True, post_data={})
+        self.source_to_public()
+        self.assertPermissionLevel(
+            url, self.SOURCE_EDIT, is_json=True, post_data={})
+
+    def test_upload_button_requires_edit_perm(self):
+        url = reverse('browse_images', args=[self.source.pk])
+
+        # TODO: Make a similar method to assertPermissionLevel which takes
+        # an arbitrary boolean-returning function and tests it on all possible
+        # permission levels (not just Edit and View). Pass
+        # button_is_present as the boolean function.
+
+        def button_is_present():
+            response = self.client.get(url, follow=True)
+            response_soup = BeautifulSoup(response.content, 'html.parser')
+
+            upload_button = response_soup.find(
+                'button', id='new-rate-table-form-show-button')
+            return bool(upload_button)
+
+        self.client.force_login(self.user_editor)
+        self.assertTrue(button_is_present())
+        self.client.force_login(self.user_viewer)
+        self.assertFalse(button_is_present())
+
+
+class TableUploadTest(ClientTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        # Make the action form show on Browse Images
+        cls.upload_image(cls.user, cls.source)
+
+        cls.default_atlantic = create_default_calcify_table(
+            'Atlantic', dict(),
+            name="Default Atlantic rates")
+        cls.default_indo_pacific = create_default_calcify_table(
+            'Indo-Pacific', dict(),
+            name="Default Indo-Pacific rates")
+
+    def upload_table(
+            self, csv_rows, name="A name", description="A description",
+            source=None):
+
+        if source is None:
+            source = self.source
+
+        stream = StringIO()
+        stream.writelines([f'{row}\n' for row in csv_rows])
+        csv_file = ContentFile(stream.getvalue(), name='rates.csv')
+        data = dict(
+            name=name,
+            description=description,
+            csv_file=csv_file,
+        )
+
+        self.client.force_login(self.user)
+        url = reverse(
+            'calcification:rate_table_upload_ajax', args=[source.pk])
+        return self.client.post(url, data=data, follow=True)
+
+    def test_success(self):
+        response = self.upload_table(
+            [
+                'Label,Mean rate,Lower bound,Upper bound',
+                'A,3.0,2.0,4.0',
+            ],
+            "Source Indo-Pacific rates",
+            "Description goes here",
+        )
+
+        # This table should be in the DB now
+        table = CalcifyRateTable.objects.get(source=self.source)
+        self.assertEqual(table.name, "Source Indo-Pacific rates")
+        self.assertEqual(table.description, "Description goes here")
+        self.assertDictEqual(
+            table.rates_json,
+            {str(self.labels.get(name='A').pk): dict(
+                mean='3.0', lower_bound='2.0', upper_bound='4.0')})
+
+        # Check response content
+        self.assertStatusOK(response)
+        response_json = response.json()
+        self.assertHTMLEqual(
+            response_json['tableDropdownHtml'],
+            '<select id="id_rate_table_id" name="rate_table_id">'
+            f'  <option value="{table.pk}">{table.name}</option>'
+            f'  <option value="{self.default_atlantic.pk}">'
+            f'    {self.default_atlantic.name}</option>'
+            f'  <option value="{self.default_indo_pacific.pk}">'
+            f'    {self.default_indo_pacific.name}</option>'
+            '</select>')
+        self.assertListEqual(
+            grid_of_tables_html_to_tuples(
+                response_json['gridOfTablesHtml']),
+            [
+                ("Source Indo-Pacific rates", "Description goes here",
+                 reverse(
+                     'calcification:rate_table_download', args=[table.pk]),
+                 reverse(
+                     'calcification:rate_table_delete_ajax', args=[table.pk])),
+                ("Default Atlantic rates", "",
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_atlantic.pk]),
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_atlantic.pk])),
+                ("Default Indo-Pacific rates", "",
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_indo_pacific.pk]),
+                 reverse(
+                     'calcification:rate_table_download',
+                     args=[self.default_indo_pacific.pk])),
+            ]
+        )
+
+    def test_csv_file_required(self):
+        data = dict(
+            name="Name",
+            description="Description",
+            csv_file="",
+        )
+        url = reverse(
+            'calcification:rate_table_upload_ajax', args=[self.source.pk])
+        self.client.force_login(self.user)
+        response = self.client.post(url, data=data, follow=True)
+
+        self.assertEqual(
+            response.json()['error'],
+            "CSV file: Please select a CSV file.")
+
+    def test_csv_wrong_file_format(self):
+        """
+        Do at least basic detection of non-CSV files.
+        """
+        data = dict(
+            name="Name",
+            description="Description",
+            csv_file=sample_image_as_file('A.jpg'),
+        )
+        url = reverse(
+            'calcification:rate_table_upload_ajax', args=[self.source.pk])
+        self.client.force_login(self.user)
+        response = self.client.post(url, data=data, follow=True)
+
+        self.assertEqual(
+            response.json()['error'],
+            "CSV file: The selected file is not a CSV file.")
+
+    def test_csv_columns_different_case(self):
+        """
+        The CSV column names can use different upper/lower case and still
+        be matched to the expected column names.
+        """
+        self.upload_table([
+            'label,meaN RatE,LOWER BOUND,Upper bound',
+            'A,3.0,2.0,4.0',
+        ])
+
+        table = CalcifyRateTable.objects.get(source=self.source)
+        self.assertDictEqual(
+            table.rates_json,
+            {str(self.labels.get(name='A').pk): dict(
+                mean='3.0', lower_bound='2.0', upper_bound='4.0')})
+
+    def test_csv_missing_column(self):
+        """Should return an error when missing a required column."""
+        response = self.upload_table([
+            'Label,Mean rate,Lower bound',
+            'A,3.0,2.0',
+        ])
+
+        self.assertEqual(
+            response.json()['error'],
+            "CSV must have a column called Upper bound")
+
+    def test_csv_unrecognized_label(self):
+        response = self.upload_table([
+            'Label,Mean rate,Lower bound,Upper bound',
+            'F,3.0,2.0,4.0',
+        ])
+
+        self.assertEqual(
+            response.json()['error'], "Label name not found: F")
+
+    def test_csv_non_number_mean_rate(self):
+        response = self.upload_table([
+            'Label,Mean rate,Lower bound,Upper bound',
+            'A,three,2.0,4.0',
+        ])
+
+        self.assertEqual(
+            response.json()['error'],
+            "mean value 'three'"
+            " couldn't be converted to a number.")
+
+    def test_csv_non_number_lower_bound(self):
+        response = self.upload_table([
+            'Label,Mean rate,Lower bound,Upper bound',
+            'A,3.0,two,4.0',
+        ])
+
+        self.assertEqual(
+            response.json()['error'],
+            "lower_bound value 'two'"
+            " couldn't be converted to a number.")
+
+    def test_csv_non_number_upper_bound(self):
+        response = self.upload_table([
+            'Label,Mean rate,Lower bound,Upper bound',
+            'A,3.0,2.0,four',
+        ])
+
+        self.assertEqual(
+            response.json()['error'],
+            "upper_bound value 'four'"
+            " couldn't be converted to a number.")
+
+    def test_name_required(self):
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="",
+        )
+
+        self.assertEqual(
+            response.json()['error'], "Name: This field is required.")
+
+    def test_name_too_long(self):
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="A"*81,
+        )
+
+        self.assertEqual(
+            response.json()['error'],
+            "Name: Ensure this value has at most 80 characters (it has 81).")
+
+    def test_name_dupe_within_source(self):
+        self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="A table",
+        )
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="A table",
+        )
+
+        self.assertEqual(
+            response.json()['error'],
+            "Name: This source already has a rate table with the same name.")
+
+    def test_name_same_as_other_source_table(self):
+        self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="A table",
+        )
+
+        source2 = self.create_source(self.user)
+        self.create_labelset(self.user, source2, self.labels)
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="A table",
+            source=source2,
+        )
+
+        # Should be OK
+        self.assertNotIn('error', response.json())
+        table = CalcifyRateTable.objects.get(source=source2)
+        self.assertEqual(table.name, "A table")
+
+    def test_name_same_as_default_table(self):
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="Default Atlantic rates",
+        )
+
+        # Should be OK
+        self.assertNotIn('error', response.json())
+        table = CalcifyRateTable.objects.get(source=self.source)
+        self.assertEqual(table.name, "Default Atlantic rates")
+
+    def test_description_optional(self):
+        self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            description="",
+        )
+
+        table = CalcifyRateTable.objects.get(source=self.source)
+        self.assertEqual(table.description, "")
+
+    def test_description_too_long(self):
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            description="A"*501,
+        )
+
+        self.assertEqual(
+            response.json()['error'],
+            "Description: Ensure this value has at most 500 characters"
+            " (it has 501).")
+
+    def test_already_have_5_tables(self):
+        for i in range(5):
+            self.upload_table(
+                ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+                name=f"Table {i}")
+
+        response = self.upload_table(
+            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            name="Another table")
+
+        self.assertEqual(
+            response.json()['error'],
+            "Up to 5 rate tables can be saved."
+            " You must delete a table before saving a new one.")

--- a/project/calcification/tests/utils.py
+++ b/project/calcification/tests/utils.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+
 from ..models import CalcifyRateTable
 
 
@@ -6,7 +8,7 @@ def create_default_calcify_table(
     if name is None:
         name = "Table Name - {}".format(region)
     if description is None:
-        description = "Table Description"
+        description = ""
 
     table = CalcifyRateTable(
         name=name,
@@ -17,3 +19,43 @@ def create_default_calcify_table(
     )
     table.save()
     return table
+
+
+def create_source_calcify_table(
+        source, rates_dict, name=None, description=None):
+    if name is None:
+        name = "Table Name"
+    if description is None:
+        description = ""
+
+    table = CalcifyRateTable(
+        name=name,
+        description=description,
+        rates_json=rates_dict,
+        source=source,
+        region='',
+    )
+    table.save()
+    return table
+
+
+def grid_of_tables_html_to_tuples(html):
+    """
+    This function facilitates checking the grid of tables HTML for the
+    expected contents.
+    """
+    soup = BeautifulSoup(html, 'html.parser')
+    data_rows = soup.find_all('tr')[1:]
+    tuples = []
+    for row in data_rows:
+        cells = row.find_all('td')
+        tuples.append((
+            # Name
+            cells[0].text,
+            # Description
+            cells[1].text,
+            # Download/Delete forms
+            cells[2].findAll('form')[0].attrs.get('action'),
+            cells[2].findAll('form')[1].attrs.get('action'),
+        ))
+    return tuples

--- a/project/calcification/tests/utils.py
+++ b/project/calcification/tests/utils.py
@@ -1,10 +1,16 @@
 from ..models import CalcifyRateTable
 
 
-def create_default_calcify_table(region, rates_dict):
+def create_default_calcify_table(
+        region, rates_dict, name=None, description=None):
+    if name is None:
+        name = "Table Name - {}".format(region)
+    if description is None:
+        description = "Table Description"
+
     table = CalcifyRateTable(
-        name="Table Name - {}".format(region),
-        description="Table Description",
+        name=name,
+        description=description,
         rates_json=rates_dict,
         source=None,
         region=region,

--- a/project/calcification/tests/utils.py
+++ b/project/calcification/tests/utils.py
@@ -1,16 +1,13 @@
 from ..models import CalcifyRateTable
 
 
-class CalcifyTestMixin:
-
-    @staticmethod
-    def create_global_rate_table(region, rates_dict):
-        table = CalcifyRateTable(
-            name="Table Name - {}".format(region),
-            description="Table Description",
-            rates_json=rates_dict,
-            source=None,
-            region=region,
-        )
-        table.save()
-        return table
+def create_default_calcify_table(region, rates_dict):
+    table = CalcifyRateTable(
+        name="Table Name - {}".format(region),
+        description="Table Description",
+        rates_json=rates_dict,
+        source=None,
+        region=region,
+    )
+    table.save()
+    return table

--- a/project/calcification/urls.py
+++ b/project/calcification/urls.py
@@ -1,12 +1,23 @@
-from django.urls import path
+from django.urls import include, path
 
 from . import views
 
 
 app_name = 'calcification'
 
-urlpatterns = [
+general_urlpatterns = [
     path('table_download/<int:table_id>/',
          views.rate_table_download,
          name='rate_table_download'),
+]
+
+source_urlpatterns = [
+    path('stats_export/',
+         views.CalcifyStatsExportView.as_view(),
+         name='stats_export'),
+]
+
+urlpatterns = [
+    path('calcification/', include(general_urlpatterns)),
+    path('source/<int:source_id>/calcification/', include(source_urlpatterns)),
 ]

--- a/project/calcification/urls.py
+++ b/project/calcification/urls.py
@@ -9,12 +9,18 @@ general_urlpatterns = [
     path('table_download/<int:table_id>/',
          views.rate_table_download,
          name='rate_table_download'),
+    path('table_delete/<int:table_id>/',
+         views.rate_table_delete_ajax,
+         name='rate_table_delete_ajax'),
 ]
 
 source_urlpatterns = [
     path('stats_export/',
          views.CalcifyStatsExportView.as_view(),
          name='stats_export'),
+    path('table_upload/',
+         views.rate_table_upload_ajax,
+         name='rate_table_upload_ajax'),
 ]
 
 urlpatterns = [

--- a/project/calcification/utils.py
+++ b/project/calcification/utils.py
@@ -3,6 +3,8 @@ import csv
 from django.core.cache import cache
 
 from labels.models import Label
+from lib.exceptions import FileProcessError
+from upload.utils import csv_to_dict
 from .models import CalcifyRateTable
 
 
@@ -39,7 +41,50 @@ def label_has_calcify_rates(label):
     ])
 
 
-def rate_table_json_to_csv(csv_stream, rate_table):
+def rate_table_csv_to_json(csv_stream):
+    csv_data = csv_to_dict(
+        csv_stream=csv_stream,
+        required_columns=[
+            ('label_name', "Label"),
+            ('mean', "Mean rate"),
+            ('lower_bound', "Lower bound"),
+            ('upper_bound', "Upper bound"),
+        ],
+        optional_columns=[],
+        key_columns=['label_name'],
+        multiple_rows_per_key=False,
+    )
+
+    rates_json = dict()
+
+    for label_name, label_rate_data in csv_data.items():
+
+        try:
+            # Case insensitive name search
+            label_id = Label.objects.get(name__iexact=label_name).pk
+        except Label.DoesNotExist:
+            raise FileProcessError(
+                "Label name not found: {}".format(label_name))
+
+        # Ensure rates are numbers
+        for key in ['mean', 'lower_bound', 'upper_bound']:
+            try:
+                float(label_rate_data[key])
+            except ValueError:
+                raise FileProcessError(
+                    f"{key} value '{label_rate_data[key]}'"
+                    " couldn't be converted to a number.")
+
+        rates_json[label_id] = dict(
+            mean=label_rate_data['mean'],
+            lower_bound=label_rate_data['lower_bound'],
+            upper_bound=label_rate_data['upper_bound'],
+        )
+
+    return rates_json
+
+
+def rate_table_json_to_csv(csv_stream, rate_table, source=None):
     fieldnames = [
         "Label",
         "Mean rate",
@@ -50,18 +95,48 @@ def rate_table_json_to_csv(csv_stream, rate_table):
     writer.writeheader()
 
     rates = rate_table.rates_json
-    label_ids = [label_id for label_id in rates.keys()]
-    # Get the label names we need with O(1) queries.
-    label_names = {
-        str(label['pk']): label['name']
-        for label
-        in Label.objects.filter(pk__in=label_ids).values('pk', 'name')
-    }
 
-    for label_id, label_rates in rates.items():
-        writer.writerow({
-            "Label": label_names[label_id],
-            "Mean rate": label_rates['mean'],
-            "Lower bound": label_rates['lower_bound'],
-            "Upper bound": label_rates['upper_bound'],
-        })
+    if source:
+
+        # Include all entries in the given source's labelset.
+
+        label_ids_and_names = {
+            str(label['pk']): label['name']
+            for label
+            in source.labelset.get_globals().values('pk', 'name')
+        }
+
+        for label_id, label_name in label_ids_and_names.items():
+            if label_id in rates:
+                label_rates = rates[label_id]
+            else:
+                # Default to 0s
+                label_rates = dict(
+                    mean='0.0', lower_bound='0.0', upper_bound='0.0')
+
+            writer.writerow({
+                "Label": label_name,
+                "Mean rate": label_rates['mean'],
+                "Lower bound": label_rates['lower_bound'],
+                "Upper bound": label_rates['upper_bound'],
+            })
+
+    else:
+
+        # Include all entries in the rate table.
+
+        label_ids = [label_id for label_id in rates.keys()]
+        # Get the label names we need with O(1) queries.
+        label_names = {
+            str(label['pk']): label['name']
+            for label
+            in Label.objects.filter(pk__in=label_ids).values('pk', 'name')
+        }
+
+        for label_id, label_rates in rates.items():
+            writer.writerow({
+                "Label": label_names[label_id],
+                "Mean rate": label_rates['mean'],
+                "Lower bound": label_rates['lower_bound'],
+                "Upper bound": label_rates['upper_bound'],
+            })

--- a/project/calcification/utils.py
+++ b/project/calcification/utils.py
@@ -8,12 +8,8 @@ from .models import CalcifyRateTable
 
 def get_default_calcify_tables():
     # Get the latest global table from each region.
-    tables = CalcifyRateTable.objects.filter(source__isnull=True).order_by(
+    return CalcifyRateTable.objects.filter(source__isnull=True).order_by(
         'region', '-date').distinct('region')
-    return {
-        table.region: table
-        for table in tables
-    }
 
 
 def get_default_calcify_rates():
@@ -27,8 +23,8 @@ def get_default_calcify_rates():
     # No cached value available
     tables = get_default_calcify_tables()
     rates = {
-        region: table.rates_json
-        for region, table in tables.items()
+        table.region: table.rates_json
+        for table in tables
     }
     # Cache for 10 minutes
     cache.set(cache_key, rates, 60*10)

--- a/project/calcification/views.py
+++ b/project/calcification/views.py
@@ -1,8 +1,13 @@
+from collections import Counter
+import csv
+import datetime
 import re
 
 from django.shortcuts import get_object_or_404
 
 from export.utils import create_csv_stream_response
+from export.views import SourceCsvExportView
+from .forms import ExportCalcifyStatsForm
 from .models import CalcifyRateTable
 from .utils import rate_table_json_to_csv
 
@@ -29,3 +34,124 @@ def rate_table_download(request, table_id):
     rate_table_json_to_csv(response, rate_table)
 
     return response
+
+
+class CalcifyStatsExportView(SourceCsvExportView):
+
+    def get_export_filename(self, source):
+        # Current date as YYYY-MM-DD
+        current_date = datetime.datetime.now(
+            datetime.timezone.utc).strftime('%Y-%m-%d')
+        return f'{source.name} - Calcification rates - {current_date}.csv'
+
+    def get_export_form(self, source, data):
+        return ExportCalcifyStatsForm(source=source, data=data)
+
+    def write_csv(self, response, source, image_set, export_form_data):
+
+        calcify_rate_table = CalcifyRateTable.objects.get(
+            pk=export_form_data['rate_table_id'])
+        calcify_rates = calcify_rate_table.rates_json
+
+        label_ids_to_names = {
+            str(label['pk']): label['name']
+            for label
+            in source.labelset.get_globals().values('pk', 'name')
+        }
+
+        optional_columns = export_form_data['optional_columns']
+
+        fieldnames = [
+            "Image ID", "Image name",
+            "Mean rate", "Lower bound", "Upper bound",
+        ]
+        if 'per_label_mean' in optional_columns:
+            fieldnames.extend([
+                f"{name} M" for name in label_ids_to_names.values()
+            ])
+        if 'per_label_bounds' in optional_columns:
+            fieldnames.extend([
+                f"{name} LB" for name in label_ids_to_names.values()
+            ])
+            fieldnames.extend([
+                f"{name} UB" for name in label_ids_to_names.values()
+            ])
+
+        writer = csv.DictWriter(response, fieldnames)
+        writer.writeheader()
+
+        # Limit decimal places in the final numbers.
+        def float_format(flt):
+            # Always 3 decimal places (even if the trailing places are 0).
+            s = format(flt, '.3f')
+            if s == '-0.000':
+                # Python has negative 0, but we don't care for that here.
+                return '0.000'
+            return s
+
+        for image in image_set:
+
+            # Counter for annotations of each label. Initialize by giving each
+            # label a 0 count.
+            label_counter = Counter({
+                label_id: 0
+                for label_id in label_ids_to_names.keys()
+            })
+
+            annotation_labels = image.annotation_set.values_list(
+                'label_id', flat=True)
+            annotation_labels = [str(pk) for pk in annotation_labels]
+            label_counter.update(annotation_labels)
+            total = len(annotation_labels)
+
+            row = {
+                "Image ID": image.pk,
+                "Image name": image.metadata.name,
+                "Mean rate": 0,
+                "Lower bound": 0,
+                "Upper bound": 0,
+            }
+
+            for label_id, count in label_counter.items():
+
+                if label_id in calcify_rates:
+                    label_mean = float(calcify_rates[label_id]['mean'])
+                    label_lower_bound = float(
+                        calcify_rates[label_id]['lower_bound'])
+                    label_upper_bound = float(
+                        calcify_rates[label_id]['upper_bound'])
+                else:
+                    # Default to 0 (meaning, this label is assumed to have
+                    # no net effect on calcification)
+                    label_mean = 0
+                    label_lower_bound = 0
+                    label_upper_bound = 0
+
+                if total > 0:
+                    coverage = count / total
+                else:
+                    coverage = 0
+
+                mean_contribution = coverage * label_mean
+                lower_bound_contribution = coverage * label_lower_bound
+                upper_bound_contribution = coverage * label_upper_bound
+
+                row["Mean rate"] += mean_contribution
+                row["Lower bound"] += lower_bound_contribution
+                row["Upper bound"] += upper_bound_contribution
+
+                label_name = label_ids_to_names[label_id]
+
+                if 'per_label_mean' in optional_columns:
+                    row[f"{label_name} M"] = float_format(mean_contribution)
+                if 'per_label_bounds' in optional_columns:
+                    row[f"{label_name} LB"] = float_format(
+                        lower_bound_contribution)
+                    row[f"{label_name} UB"] = float_format(
+                        upper_bound_contribution)
+
+            row["Mean rate"] = float_format(row["Mean rate"])
+            row["Lower bound"] = float_format(row["Lower bound"])
+            row["Upper bound"] = float_format(row["Upper bound"])
+
+            writer.writerow(row)

--- a/project/calcification/views.py
+++ b/project/calcification/views.py
@@ -3,21 +3,73 @@ import csv
 import datetime
 import re
 
-from django.shortcuts import get_object_or_404
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.template.loader import render_to_string
+from django.views.decorators.http import require_GET, require_POST
 
 from export.utils import create_csv_stream_response
 from export.views import SourceCsvExportView
-from .forms import ExportCalcifyStatsForm
+from images.models import Source
+from lib.decorators import source_permission_required
+from lib.exceptions import FileProcessError
+from lib.forms import get_one_form_error
+from upload.utils import text_file_to_unicode_stream
+from .forms import CalcifyRateTableForm, ExportCalcifyStatsForm
 from .models import CalcifyRateTable
-from .utils import rate_table_json_to_csv
+from .utils import (
+    get_default_calcify_tables, rate_table_csv_to_json, rate_table_json_to_csv)
 
 
-# TODO: Whenever we implement saving user-defined tables: If the table belongs to a source, require permission to that source.
+@require_GET
 def rate_table_download(request, table_id):
     """
-    Main page for a particular label
+    Download a calcification rate table as CSV.
     """
-    rate_table = get_object_or_404(CalcifyRateTable, id=table_id)
+    def render_permission_error(request, message):
+        return render(request, 'permission_denied.html', dict(error=message))
+
+    table_permission_error_message = \
+        f"You don't have permission to download table of ID {table_id}."
+
+    try:
+        rate_table = CalcifyRateTable.objects.get(pk=table_id)
+    except CalcifyRateTable.DoesNotExist:
+        # Technically the error message isn't accurate here, since it
+        # implies the table ID exists. But users don't really have any
+        # business knowing which table IDs exist or not outside their source.
+        # So this obfuscation makes sense.
+        return render_permission_error(request, table_permission_error_message)
+
+    if rate_table.source:
+        if not rate_table.source.visible_to_user(request.user):
+            # Table belongs to a source, and the user doesn't have access to
+            # that source.
+            return render_permission_error(
+                request, table_permission_error_message)
+
+    # The source_id parameter tells us to limit the downloaded CSV to the
+    # entries in the specified source's labelset, rather than including all
+    # the rows of the rate table. This is particularly useful when downloading
+    # a default rate table.
+    if 'source_id' in request.GET:
+        source_id = request.GET['source_id']
+        source_permission_error_message = \
+            f"You don't have permission to access source of ID {source_id}."
+
+        try:
+            source = Source.objects.get(pk=source_id)
+        except Source.DoesNotExist:
+            return render_permission_error(
+                request, source_permission_error_message)
+
+        if not source.visible_to_user(request.user):
+            return render_permission_error(
+                request, source_permission_error_message)
+    else:
+        source = None
+
+    # At this point we do have permission, so proceed.
 
     # Convert the rate table's name to a valid filename in Windows and
     # Linux/Mac (or at least make a reasonable effort to).
@@ -31,7 +83,7 @@ def rate_table_download(request, table_id):
 
     # Make a CSV stream response and write the data to it.
     response = create_csv_stream_response('{}.csv'.format(csv_filename))
-    rate_table_json_to_csv(response, rate_table)
+    rate_table_json_to_csv(response, rate_table, source=source)
 
     return response
 
@@ -201,3 +253,107 @@ class CalcifyStatsExportView(SourceCsvExportView):
                 summary_row[f"{label_name} UB"] = float_format(
                     upper_bound_contribution_sums[label_name] / num_images)
         writer.writerow(summary_row)
+
+
+def response_after_table_upload_or_delete(request, source):
+    """Helper function for upload and delete views."""
+
+    # Re-render the rate table dropdown.
+    blank_export_form = ExportCalcifyStatsForm(source=source)
+    table_dropdown_html = str(blank_export_form['rate_table_id'])
+
+    # Re-render the table-management grid.
+    grid_of_tables_html = render_to_string(
+        'calcification/grid_of_tables.html',
+        dict(
+            source_calcification_tables=source.calcifyratetable_set.order_by(
+                'name'),
+            default_calcification_tables=get_default_calcify_tables(),
+            can_manage_calcification_tables=request.user.has_perm(
+                Source.PermTypes.EDIT.code, source),
+        ),
+        # Passing the request gives us a RequestContext, which allows
+        # rendering of the CSRF token.
+        request,
+    )
+
+    # Return both in the Ajax response so they can be replaced via Javascript.
+    return JsonResponse(dict(
+        tableDropdownHtml=table_dropdown_html,
+        gridOfTablesHtml=grid_of_tables_html,
+    ))
+
+
+@require_POST
+@source_permission_required(
+    'source_id', perm=Source.PermTypes.EDIT.code, ajax=True)
+def rate_table_upload_ajax(request, source_id):
+    """
+    Upload a calcification rate table as CSV to the specified source.
+    """
+    source = Source.objects.get(pk=source_id)
+
+    MAX_TABLE_COUNT = 5
+    if source.calcifyratetable_set.count() >= MAX_TABLE_COUNT:
+        return JsonResponse(dict(
+            error=f"Up to {MAX_TABLE_COUNT} rate tables can be saved."
+                  " You must delete a table before saving a new one."))
+
+    form = CalcifyRateTableForm(source, request.POST, request.FILES)
+
+    if not form.is_valid():
+        # Find the first error and return it.
+        return JsonResponse(dict(error=get_one_form_error(form)))
+
+    # The above just checks for a valid CSV file. Now we process the CSV and
+    # check that we can parse a rate table from it.
+    try:
+        rates_json = rate_table_csv_to_json(
+            text_file_to_unicode_stream(form.cleaned_data['csv_file']))
+    except FileProcessError as error:
+        return JsonResponse(dict(
+            error=str(error),
+        ))
+
+    # Save the table.
+    table = CalcifyRateTable(
+        name=form.cleaned_data['name'],
+        description=form.cleaned_data['description'],
+        rates_json=rates_json,
+        source_id=source_id,
+    )
+    table.save()
+
+    return response_after_table_upload_or_delete(request, source)
+
+
+@require_POST
+def rate_table_delete_ajax(request, table_id):
+    """
+    Delete a calcification rate table belonging to a source.
+    """
+    permission_error_message = \
+        f"You don't have permission to delete table of ID {table_id}."
+
+    try:
+        rate_table = CalcifyRateTable.objects.get(pk=table_id)
+    except CalcifyRateTable.DoesNotExist:
+        # Technically the error message isn't accurate here, since it
+        # implies the table ID exists. But users don't really have any
+        # business knowing which table IDs exist or not outside their source.
+        # So this obfuscation makes sense.
+        return JsonResponse(dict(error=permission_error_message))
+
+    if rate_table.source is None:
+        # Can't delete default tables.
+        return JsonResponse(dict(error=permission_error_message))
+
+    if not request.user.has_perm(
+            Source.PermTypes.EDIT.code, rate_table.source):
+        # Don't have the proper permission to this source.
+        return JsonResponse(dict(error=permission_error_message))
+
+    # Do have permission.
+    rate_table.delete()
+
+    return response_after_table_upload_or_delete(request, rate_table.source)

--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     # These apps don't have uniform prefixes. We'll trust them to provide
     # their own non-clashing URL patterns.
     path('', include('annotations.urls')),
+    path('', include('calcification.urls', namespace='calcification')),
     path('', include('images.urls')),
     path('', include('labels.urls')),
 
@@ -20,8 +21,6 @@ urlpatterns = [
     path('async_media/',
          include('async_media.urls', namespace='async_media')),
     path('blog/', include('blog.urls', namespace='blog')),
-    path('calcification/',
-         include('calcification.urls', namespace='calcification')),
     path('source/<int:source_id>/browse/', include('visualization.urls')),
     path('source/<int:source_id>/export/', include('export.urls')),
     path('source/<int:source_id>/upload/', include('upload.urls')),

--- a/project/export/tests/test_covers.py
+++ b/project/export/tests/test_covers.py
@@ -57,7 +57,7 @@ class ImageSetTest(BaseExportTest):
         self.assert_csv_content_equal(response.content, expected_lines)
 
     def test_all_images_multiple(self):
-        """Export for 1 out of 1 images."""
+        """Export for n out of n images."""
         self.img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
         self.img2 = self.upload_image(

--- a/project/export/utils.py
+++ b/project/export/utils.py
@@ -15,7 +15,11 @@ from visualization.forms import create_image_filter_form
 
 
 def get_request_images(request, source):
-    image_form = create_image_filter_form(request.POST, source)
+    if request.POST:
+        image_form = create_image_filter_form(request.POST, source)
+    else:
+        image_form = create_image_filter_form(request.GET, source)
+
     if image_form:
         if image_form.is_valid():
             image_set = image_form.get_images()

--- a/project/labels/templates/labels/label_main.html
+++ b/project/labels/templates/labels/label_main.html
@@ -52,7 +52,7 @@
     <dt>
       Calcification rate data:
       <div class="tutorial-message">
-        {% include "calcification/help_default_rates.html" with calcification_table_ids=calcification_table_ids %}
+        {% include "calcification/help_default_rates.html" with calcification_tables=calcification_tables %}
       </div>
     </dt>
     <dd class="calcification-rate-data">

--- a/project/labels/tests/test_label_list.py
+++ b/project/labels/tests/test_label_list.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from calcification.tests.utils import CalcifyTestMixin
+from calcification.tests.utils import create_default_calcify_table
 from images.model_utils import PointGen
 from lib.tests.utils import BasePermissionTest, ClientTest
 from ..models import LabelGroup, Label
@@ -28,7 +28,7 @@ class PermissionTest(BasePermissionTest):
         self.assertPermissionLevel(url, self.SIGNED_OUT, is_json=True)
 
 
-class LabelListTest(ClientTest, CalcifyTestMixin):
+class LabelListTest(ClientTest):
     """
     Test the label list page.
     """
@@ -108,10 +108,10 @@ class LabelListTest(ClientTest, CalcifyTestMixin):
         label_b = self.labels.get(name='B')
         label_c = self.labels.get(name='C')
 
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Atlantic', {
                 label_c.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Indo-Pacific', {
                 label_b.pk: dict(mean=5, lower_bound=4, upper_bound=6),
                 label_c.pk: dict(mean=2, lower_bound=1, upper_bound=3)})

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -500,11 +500,11 @@ class CalcificationRatesTest(ClientTest):
             'calcification:rate_table_download', args=[atlantic_table.pk])
         indo_pacific_download_url = reverse(
             'calcification:rate_table_download', args=[indo_pacific_table.pk])
-        self.assertIn(
+        self.assertInHTML(
             f'<a href="{atlantic_download_url}">Atlantic</a>',
             str(help_dialog_tag),
-            msg="Atlantic table download link should be present")
-        self.assertIn(
+            msg_prefix="Atlantic table download link should be present")
+        self.assertInHTML(
             f'<a href="{indo_pacific_download_url}">Indo-Pacific</a>',
             str(help_dialog_tag),
-            msg="Indo-Pacific table download link should be present")
+            msg_prefix="Indo-Pacific table download link should be present")

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 from django.urls import reverse
 from django.utils.html import escape as html_escape
 
-from calcification.tests.utils import CalcifyTestMixin
+from calcification.tests.utils import create_default_calcify_table
 from images.model_utils import PointGen
 from images.models import Source
 from lib.tests.utils import (
@@ -385,7 +385,7 @@ class PopularityTest(ClientTest):
             msg="Cached popularity of 0 should still be used")
 
 
-class CalcificationRatesTest(ClientTest, CalcifyTestMixin):
+class CalcificationRatesTest(ClientTest):
     """Label-main-page tests related to label calcification rates."""
 
     @classmethod
@@ -409,10 +409,10 @@ class CalcificationRatesTest(ClientTest, CalcifyTestMixin):
         """No calcification rate data for the label."""
 
         # 2 regions defined, but only label B gets rates
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Atlantic', {
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Indo-Pacific', {
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
 
@@ -431,10 +431,10 @@ class CalcificationRatesTest(ClientTest, CalcifyTestMixin):
         The label has calcification rate data for at least one, but not
         all of the regions.
         """
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Atlantic', {
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Indo-Pacific', {
                 self.label_a.pk: dict(mean=5, lower_bound=4, upper_bound=6),
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
@@ -456,11 +456,11 @@ class CalcificationRatesTest(ClientTest, CalcifyTestMixin):
         """
         The label has calcification rate data for all regions.
         """
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Atlantic', {
                 self.label_a.pk: dict(mean=4, lower_bound=3, upper_bound=5),
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
-        self.create_global_rate_table(
+        create_default_calcify_table(
             'Indo-Pacific', {
                 self.label_a.pk: dict(mean=5, lower_bound=4, upper_bound=6),
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
@@ -484,10 +484,10 @@ class CalcificationRatesTest(ClientTest, CalcifyTestMixin):
         The calcification rates help dialog should have download links to the
         latest default tables.
         """
-        atlantic_table = self.create_global_rate_table(
+        atlantic_table = create_default_calcify_table(
             'Atlantic', {
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
-        indo_pacific_table = self.create_global_rate_table(
+        indo_pacific_table = create_default_calcify_table(
             'Indo-Pacific', {
                 self.label_a.pk: dict(mean=5, lower_bound=4, upper_bound=6),
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})

--- a/project/labels/views.py
+++ b/project/labels/views.py
@@ -392,15 +392,11 @@ def label_main(request, label_id):
     # Create a dict of the rates from each region, if available for this label.
     # If this label doesn't have rates defined in any region, then this is an
     # empty dict.
-    tables_by_region = get_default_calcify_tables()
+    calcification_tables = get_default_calcify_tables()
     calcification_rates = {
-        region: table.rates_json[str(label_id)]
-        for region, table in tables_by_region.items()
+        table.region: table.rates_json[str(label_id)]
+        for table in calcification_tables
         if str(label_id) in table.rates_json
-    }
-    calcification_table_ids = {
-        region: table.pk
-        for region, table in tables_by_region.items()
     }
 
     # Label usage stats
@@ -411,7 +407,7 @@ def label_main(request, label_id):
         'label': label,
         'can_edit_label': is_label_editable_by_user(label, request.user),
         'calcification_rates': calcification_rates,
-        'calcification_table_ids': calcification_table_ids,
+        'calcification_tables': calcification_tables,
         'users_sources': users_sources,
         'other_public_sources': other_public,
         'other_private_sources': other_private,

--- a/project/lib/static/js/util.js
+++ b/project/lib/static/js/util.js
@@ -25,6 +25,31 @@ var util = {
         }
     },
 
+    /*
+    Wrapper around the standard fetch() which does error handling.
+    @param resource - url or other resource to fetch (see standard fetch())
+    @param init - options (see standard fetch())
+    @param callback - function to call when the response status is OK
+    */
+    fetch: function(resource, init, callback) {
+        fetch(resource, init)
+            .then(response => {
+                if (!response.ok) {
+                    // This can be "Internal server error" for example.
+                    throw new Error(response.statusText);
+                }
+                return response.json();
+            })
+            .then(callback)
+            .catch(error => {
+                alert(
+                    "There was an error:" +
+                    `\n${error}` +
+                    "\nIf the problem persists, please notify us on the forum."
+                );
+            });
+    },
+
     /* Takes a number representing a number of bytes, and returns a
      * human-readable filesize string in B, KB, or MB. */
     filesizeDisplay: function(bytes) {
@@ -42,6 +67,10 @@ var util = {
         }
     },
 
+    /*
+    Can be used to catch and alert about errors from jQuery ajax calls.
+    For the non-jQuery fetch(), see util.fetch() instead.
+    */
     handleServerError: function(jqXHR, textStatus, errorThrown) {
         if (textStatus === 'abort') {
             // A manually aborted request, not a server issue.

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -7,6 +7,7 @@ import math
 import posixpath
 import random
 from unittest import mock
+import urllib.parse
 from urllib.parse import quote as url_quote
 
 from spacer.messages import ClassifyReturnMsg
@@ -718,6 +719,18 @@ class BasePermissionTest(ClientTest):
     def source_to_public(cls):
         cls.source.visibility = Source.VisibilityTypes.PUBLIC
         cls.source.save()
+
+    @staticmethod
+    def make_url_with_params(base_url, params):
+        """
+        Any permission tests involving GET params should encode the GET data in
+        the URL, rather than handling it the way POST data is handled (passing
+        a dict).
+        This way, any `assertRedirects` calls within a `assertPermissionLevel`
+        call can compare against the correct URL (including the GET params).
+        This is a helper method to build said URL.
+        """
+        return base_url + '?' + urllib.parse.urlencode(params)
 
     def _make_request(self, url, user, post_data):
         if user:

--- a/project/upload/forms.py
+++ b/project/upload/forms.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.images import get_image_dimensions
@@ -143,6 +145,28 @@ class ImageUploadForm(Form):
         return self.cleaned_data['file']
 
 
+class CsvFileField(FileField):
+    default_error_messages = {
+        'required': "Please select a CSV file.",
+    }
+
+    def clean(self, data, initial=None):
+        data = super().clean(data, initial=initial)
+
+        # Naively validate that the file is a CSV file through
+        # (1) given MIME type, or (2) file extension. Either of them
+        # can be faked though.
+        if data.content_type == 'text/csv':
+            pass
+        elif mimetypes.guess_type(data.name) == 'text/csv':
+            pass
+        else:
+            raise ValidationError("The selected file is not a CSV file.")
+
+        return data
+
+
+# TODO: Consider porting usages to the newer CsvFileField instead.
 class CSVImportForm(Form):
     csv_file = FileField(
         label='CSV file',

--- a/project/visualization/static/css/browse.css
+++ b/project/visualization/static/css/browse.css
@@ -29,7 +29,11 @@ div#action-box form {
 label {
     width: auto;
 }
-
+button#manage-calcify-tables-button {
+    /* Horizontally center the button */
+    display: block;
+    margin: auto;
+}
 
 /* Image/patch thumbnail grid, indicating annotation status. */
 img.thumb.confirmed, img.thumb.annotated {

--- a/project/visualization/static/css/browse.css
+++ b/project/visualization/static/css/browse.css
@@ -34,6 +34,17 @@ button#manage-calcify-tables-button {
     display: block;
     margin: auto;
 }
+table#table-of-calcify-tables td.description {
+    max-width: 300px;
+}
+table#table-of-calcify-tables td.actions {
+    width: 150px;
+}
+#new-rate-table-form textarea {
+    width: 250px;
+    height: 5em;
+    margin: 0;
+}
 
 /* Image/patch thumbnail grid, indicating annotation status. */
 img.thumb.confirmed, img.thumb.annotated {
@@ -54,7 +65,7 @@ img.thumb.needs_annotation {
 #id_metadata_form input[type="text"].error {
     border-color: red;
 }
-textarea {
+#id_metadata_form textarea {
     /* Make this fit better in a grid (at the expense of ease of editing). */
     width: 200px;
     height: 1.5em;

--- a/project/visualization/static/js/BrowseActionHelper.js
+++ b/project/visualization/static/js/BrowseActionHelper.js
@@ -227,19 +227,7 @@ var BrowseActionHelper = (function() {
             // Add submit button handlers.
             $actionForms.find('button.submit').click(actionSubmit);
 
-            // Show calcify table management dialog when the appropriate button
-            // is clicked.
-            document.getElementById('manage-calcify-tables-button')
-                    .addEventListener('click', function() {
-                $('#manage-calcify-tables').dialog({
-                    width: 500,
-                    height: 300,
-                    modal: true,
-                    title: "Calcification rate tables"
-                });
-            });
-
-            // Initialize.
+            // Initialize action-related states.
             onActionChange();
         }
     }

--- a/project/visualization/static/js/BrowseActionHelper.js
+++ b/project/visualization/static/js/BrowseActionHelper.js
@@ -46,6 +46,9 @@ var BrowseActionHelper = (function() {
         else if (action === 'export' && export_type === 'image_covers') {
             $currentActionForm = $('#export-image-covers-form');
         }
+        else if (action === 'export' && export_type === 'calcify_rates') {
+            $currentActionForm = $('#export-calcify-rates-form');
+        }
         else if (action === 'delete') {
             $currentActionForm = $('#delete-form');
         }
@@ -223,6 +226,18 @@ var BrowseActionHelper = (function() {
 
             // Add submit button handlers.
             $actionForms.find('button.submit').click(actionSubmit);
+
+            // Show calcify table management dialog when the appropriate button
+            // is clicked.
+            document.getElementById('manage-calcify-tables-button')
+                    .addEventListener('click', function() {
+                $('#manage-calcify-tables').dialog({
+                    width: 500,
+                    height: 300,
+                    modal: true,
+                    title: "Calcification rate tables"
+                });
+            });
 
             // Initialize.
             onActionChange();

--- a/project/visualization/templates/visualization/browse_images.html
+++ b/project/visualization/templates/visualization/browse_images.html
@@ -50,6 +50,13 @@
     {# Annotation and deletion require edit perms, and export requires login to keep out bots. So, no actions are available if not logged in. #}
     {% if user.is_authenticated %}
 
+      {# Modal dialog contents live in this hidden element until they're needed. #}
+      <div hidden>
+        <div id="manage-calcify-tables">
+          {% include "calcification/manage_tables.html" with default_calcification_tables=default_calcification_tables %}
+        </div>
+      </div>
+
       {# Fields to perform an action on one or more images #}
       <div id="action-box" class="box">
 
@@ -84,6 +91,7 @@
               <option value="annotations_cpc">Annotations, CPCe</option>
             {% endif %}
             <option value="image_covers">Image Covers</option>
+            <option value="calcify_rates">Calcification Rates</option>
           </select>
           for
         </span>
@@ -142,6 +150,20 @@
         id="export-image-covers-form">
           {% csrf_token %}
           <span class="image-select-field-container"></span>
+          <button type="button" class="submit">Go</button>
+        </form>
+
+        <form action="{% url 'calcification:stats_export' source.pk %}"
+        method="get" id="export-calcify-rates-form">
+          <hr/>
+          <span class="image-select-field-container"></span>
+
+          <button type="button" id="manage-calcify-tables-button">
+            Click here to view label rate tables
+          </button>
+
+          {% include "form_generic.html" with form=export_calcify_rates_form %}
+
           <button type="button" class="submit">Go</button>
         </form>
 

--- a/project/visualization/templates/visualization/browse_images.html
+++ b/project/visualization/templates/visualization/browse_images.html
@@ -11,6 +11,7 @@
 {% block page-specific-includes %}
   {% include "static-local-include.html" with type="js" path="js/ImageSearchHelper.js" %}
   {% include "static-local-include.html" with type="js" path="js/BrowseActionHelper.js" %}
+  {% include "static-local-include.html" with type="js" path="js/CalcifyTablesHelper.js" %}
 
   {% include "static-local-include.html" with type="css" path="css/browse.css" %}
 {% endblock %}
@@ -53,7 +54,7 @@
       {# Modal dialog contents live in this hidden element until they're needed. #}
       <div hidden>
         <div id="manage-calcify-tables">
-          {% include "calcification/manage_tables.html" with default_calcification_tables=default_calcification_tables %}
+          {% include "calcification/manage_tables.html" with calcify_table_form=calcify_table_form default_calcification_tables=default_calcification_tables %}
         </div>
       </div>
 
@@ -159,7 +160,11 @@
           <span class="image-select-field-container"></span>
 
           <button type="button" id="manage-calcify-tables-button">
-            Click here to view label rate tables
+            {% if can_manage_calcification_tables %}
+              Click here to manage label-rate tables
+            {% else %}
+              Click here to view label-rate tables
+            {% endif %}
           </button>
 
           {% include "form_generic.html" with form=export_calcify_rates_form %}
@@ -258,6 +263,8 @@
           pageImageIds: {{ page_image_ids|jsonify }},
           links: {{ links|jsonify }}
       });
+
+      let calcifyTablesHelper = new CalcifyTablesHelper({{ can_manage_calcification_tables|jsonify }});
     {% endif %}
 
     window.seleniumDebugInitRan = true;

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -64,7 +64,16 @@
     </ul>
   </li>
 
-  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, this image consists of 5% label A, 10% label B, etc. based on the annotations. Also included is the image's "annotation area", which is the area of the image where the random points are scattered.</li>
+  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, image 0001.JPG consists of 5% Acropora, 10% Porites, etc. based on the annotations. Also included is the image's "annotation area", which is the area of the image where the random points are scattered.</li>
+
+  <li><strong>Calcification Rates:</strong> Calcification rates for each image in the set. For example, image 0001.JPG's calcification rates are: mean 4.8, lower bound 3.2, upper bound 6.0. The rates are computed based on the image's annotations, and the calcification rates specified for each label (you must pick a label rate table to use). There are optional sets of columns available:
+
+    <ul>
+      <li>Per-label contributions to mean rate: This shows the per-label breakdown for the mean rate calculation. For example, image 0001.JPG has a 4.8 mean rate, and the per-label breakdown is: 4.0 from Acropora, 1.5 from Porites, -0.7 from Hard substrate. These columns will be named like "Acropora M", "Porites M", etc.</li>
+
+      <li>Per-label contributions to confidence bounds: This shows the per-label breakdowns for the lower bound and upper bound rate calculations. These columns will be named like "Acropora LB", "Porites LB", "Acropora UB", "Porites UB", etc.</li>
+    </ul>
+  </li>
 </ul>
 
 <h3>Delete</h3>

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -73,6 +73,8 @@
 
       <li>Per-label contributions to confidence bounds: This shows the per-label breakdowns for the lower bound and upper bound rate calculations. These columns will be named like "Acropora LB", "Porites LB", "Acropora UB", "Porites UB", etc.</li>
     </ul>
+
+    An "ALL IMAGES" summary row is included as the last row. This summary averages the stats over all the images, with each image being weighted equally (regardless of the number of point annotations).
   </li>
 </ul>
 

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -12,7 +12,7 @@ from .forms import CheckboxForm, StatisticsSearchForm, ImageSearchForm, \
     PatchSearchOptionsForm, HiddenForm, create_image_filter_form
 from accounts.utils import get_robot_user
 from annotations.models import Annotation
-from calcification.forms import ExportCalcifyStatsForm
+from calcification.forms import CalcifyRateTableForm, ExportCalcifyStatsForm
 from calcification.utils import get_default_calcify_tables
 from export.forms import CpcPrefsForm, ExportAnnotationsForm
 from export.utils import get_previous_cpcs_status
@@ -90,8 +90,15 @@ def browse_images(request, source_id):
         'links': links,
         'hidden_image_form': hidden_image_form,
         'export_annotations_form': ExportAnnotationsForm(),
+
         'export_calcify_rates_form': ExportCalcifyStatsForm(source=source),
+        'calcify_table_form': CalcifyRateTableForm(source=source),
+        'source_calcification_tables': source.calcifyratetable_set.order_by(
+            'name'),
         'default_calcification_tables': get_default_calcify_tables(),
+        'can_manage_calcification_tables': request.user.has_perm(
+            Source.PermTypes.EDIT.code, source),
+
         'cpc_prefs_form': CpcPrefsForm(source=source),
         'previous_cpcs_status': previous_cpcs_status,
         'empty_message': empty_message,

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -12,6 +12,8 @@ from .forms import CheckboxForm, StatisticsSearchForm, ImageSearchForm, \
     PatchSearchOptionsForm, HiddenForm, create_image_filter_form
 from accounts.utils import get_robot_user
 from annotations.models import Annotation
+from calcification.forms import ExportCalcifyStatsForm
+from calcification.utils import get_default_calcify_tables
 from export.forms import CpcPrefsForm, ExportAnnotationsForm
 from export.utils import get_previous_cpcs_status
 from images.forms import MetadataFormForGrid, BaseMetadataFormSet
@@ -88,6 +90,8 @@ def browse_images(request, source_id):
         'links': links,
         'hidden_image_form': hidden_image_form,
         'export_annotations_form': ExportAnnotationsForm(),
+        'export_calcify_rates_form': ExportCalcifyStatsForm(source=source),
+        'default_calcification_tables': get_default_calcify_tables(),
         'cpc_prefs_form': CpcPrefsForm(source=source),
         'previous_cpcs_status': previous_cpcs_status,
         'empty_message': empty_message,


### PR DESCRIPTION
Addresses the following:

- #369 - export function for per-image rates
- Half of #373 - summary stats (added for calcification, not for percent cover yet)
- #372 - accept custom label rate tables
- #377 - save custom label rate tables for later use
- #388 - save multiple custom label rate tables per source

After doing the earlier tasks, #377 and #388 turned out to be reasonably straightforward on top of accepting custom tables in the first place, so I implemented those.

To fnd the export form, go to the bottom of Browse Images, then select "Export" and "Calcification Rates" in the dropdowns. (I'd still prefer to move all the export functions to their own page for easier discoverability, but at this point I'm not sure if that will happen by the end of June.)

![01_export](https://user-images.githubusercontent.com/857711/122636166-9fd5da00-d09c-11eb-844c-bf47e6eaa744.png)

The export form has this dropdown for selecting the rate table. Choices are the custom tables uploaded to the source, followed by CoralNet's default tables:

![02_table-select-dropdown](https://user-images.githubusercontent.com/857711/122636172-a401f780-d09c-11eb-890f-1fb0e61139a1.png)

"Click here to manage label-rate tables" brings up this popup of the available tables:

![03_manage](https://user-images.githubusercontent.com/857711/122636178-a95f4200-d09c-11eb-8071-f40884f9b04d.png)

Here, the "Delete" and "Upload a new table" buttons are only available if you have Edit or Admin permissions to the source.

For the default tables, there are two "Download CSV" buttons available. The first CSV is filtered down to only the entries in the source's labelset - so if there are 20 labels in the labelset, then the CSV has 20 rows (with rates of 0 to fill in gaps as necessary). The second CSV is the entire default rate table.

Click "Upload a new table" to bring up this form:

<img src="https://user-images.githubusercontent.com/857711/122636473-525a6c80-d09e-11eb-8822-e0b4f8568ead.png" width="500px"/>

The name field is required and the description field is optional. Note that the name field doesn't need to have a date in it; I just wrote dates in my example tables' names above, to demonstrate that the name field can help with bookkeeping / traceability of the rates. The expected CSV layout is almost the same as the one we use for uploading default tables - there are `Label`, `Mean rate`, `Lower bound`, and `Upper bound` columns, but no `Region` column.

You can save up to 5 custom tables in a source. If you already have 5, you have to delete an existing table before uploading another.

Note that after uploading a table, there is no way to rename the table or edit its description/contents. So you'd have to delete and re-upload the table if you want to change any of those things. Should be a relatively minor inconvenience though.

Now for the results of the per-image rate export - without the optional columns, you get something like this:

![05_stats-csv](https://user-images.githubusercontent.com/857711/122636478-56868a00-d09e-11eb-8e5b-ba6901d284c3.png)

And with the optional columns - not all columns are visible in this screenshot, but basically there are "M" (mean), "LB" (lower bound), and "UB" (upper bound) columns for each label:

![06_stats-csv-with-extra-cols](https://user-images.githubusercontent.com/857711/122636485-59817a80-d09e-11eb-8e54-cd247cd38391.png)

The optional columns are off by default, since there can be a lot of them.

## Technical notes

`CalcifyTablesHelper.js` is my first real attempt at using modern Javascript (mostly meaning ECMAScript 6) in CoralNet. I previously was sticking to older style Javascript for consistency with the rest of the codebase, and thought it would be better to modernize all of the JS at once sometime (along with adding JS tests to make sure things don't break). But I'm currently not sure when that can happen, and I figured there was no harm in using modern JS when I have to add a new module anyway.

Also, working on this PR gave me a few ideas on improving code organization in the export and upload code. The first two of these are partially implemented:

- Use the `SourceCsvExportView` class to reuse code among the source-level CSV export views.

- Use the `CsvFileField` class instead of `CSVImportForm` for more of the CSV upload views. It's not that much of a difference, but I think "single form with CsvFileField plus other fields" would generally make for cleaner view code than "CSVImportForm plus a second form with other fields".

- Use Javascript class inheritance to improve JS code reuse among the various Upload pages.

- In general, upload and export logic specific to particular models should go in those models' respective apps. Only generic classes, functions, etc. not specific to a particular model should go in the `upload` and `export` apps. (Related: issue #74) I believe pyspacer is similar in how it organizes serialization code.
