### PR TITLE
Excel option for image stats exports + add summary row for image covers

### DIFF
--- a/project/calcification/forms.py
+++ b/project/calcification/forms.py
@@ -1,8 +1,9 @@
 from django.core.exceptions import ValidationError
-from django.forms import Form, ModelForm
+from django.forms import ModelForm
 from django.forms.fields import ChoiceField, MultipleChoiceField
 from django.forms.widgets import CheckboxSelectMultiple, Textarea
 
+from export.forms import ExportImageStatsForm
 from upload.forms import CsvFileField
 from .models import CalcifyRateTable
 from .utils import get_default_calcify_tables
@@ -25,12 +26,14 @@ def get_calcify_table_choices(source):
     return choices
 
 
-class ExportCalcifyStatsForm(Form):
+class ExportCalcifyStatsForm(ExportImageStatsForm):
     rate_table_id = ChoiceField(
         label="Label rates to use")
 
     optional_columns = MultipleChoiceField(
         widget=CheckboxSelectMultiple, required=False)
+
+    field_order = ['rate_table_id', 'optional_columns', 'label_display']
 
     def __init__(self, source, *args, **kwargs):
 

--- a/project/calcification/management/commands/import_default_calcify_table.py
+++ b/project/calcification/management/commands/import_default_calcify_table.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             required_columns=[
                 ('label_name', "Label"),
                 ('region', "Region"),
-                ('mean', "Mean rate"),
+                ('mean', "Mean"),
                 ('lower_bound', "Lower bound"),
                 ('upper_bound', "Upper bound"),
             ],

--- a/project/calcification/management/commands/import_default_calcify_table.py
+++ b/project/calcification/management/commands/import_default_calcify_table.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         csv_data = csv_to_dict(
             csv_stream=csv_unicode_stream,
             required_columns=[
-                ('label_name', "Label"),
+                ('label_name', "Name"),
                 ('region', "Region"),
                 ('mean', "Mean"),
                 ('lower_bound', "Lower bound"),

--- a/project/calcification/tests/test_commands.py
+++ b/project/calcification/tests/test_commands.py
@@ -18,13 +18,13 @@ class ImportDefaultTableTest(ManagementCommandTest):
         # Set up CSV contents
         stream = StringIO()
         columns = [
-            "Label", "Region", "Mean rate", "Lower bound", "Upper bound"]
+            "Label", "Region", "Mean", "Lower bound", "Upper bound"]
         writer = csv.DictWriter(stream, columns)
         writer.writeheader()
         writer.writerow({
             'Label': 'A',
             'Region': 'Indo-Pacific',
-            'Mean rate': '2.0',
+            'Mean': '2.0',
             'Lower bound': '1.0',
             'Upper bound': '3.0',
         })
@@ -32,14 +32,14 @@ class ImportDefaultTableTest(ManagementCommandTest):
             # Should be case insensitive
             'Label': 'a',
             'Region': 'Atlantic',
-            'Mean rate': '5.0',
+            'Mean': '5.0',
             'Lower bound': '4.0',
             'Upper bound': '7.0',
         })
         writer.writerow({
             'Label': 'B',
             'Region': 'Indo-Pacific',
-            'Mean rate': '-2.0',
+            'Mean': '-2.0',
             'Lower bound': '-3.0',
             'Upper bound': '-1.0',
         })

--- a/project/calcification/tests/test_commands.py
+++ b/project/calcification/tests/test_commands.py
@@ -18,11 +18,11 @@ class ImportDefaultTableTest(ManagementCommandTest):
         # Set up CSV contents
         stream = StringIO()
         columns = [
-            "Label", "Region", "Mean", "Lower bound", "Upper bound"]
+            "Name", "Region", "Mean", "Lower bound", "Upper bound"]
         writer = csv.DictWriter(stream, columns)
         writer.writeheader()
         writer.writerow({
-            'Label': 'A',
+            'Name': 'A',
             'Region': 'Indo-Pacific',
             'Mean': '2.0',
             'Lower bound': '1.0',
@@ -30,14 +30,14 @@ class ImportDefaultTableTest(ManagementCommandTest):
         })
         writer.writerow({
             # Should be case insensitive
-            'Label': 'a',
+            'Name': 'a',
             'Region': 'Atlantic',
             'Mean': '5.0',
             'Lower bound': '4.0',
             'Upper bound': '7.0',
         })
         writer.writerow({
-            'Label': 'B',
+            'Name': 'B',
             'Region': 'Indo-Pacific',
             'Mean': '-2.0',
             'Lower bound': '-3.0',

--- a/project/calcification/tests/test_download.py
+++ b/project/calcification/tests/test_download.py
@@ -78,7 +78,7 @@ class RateTableDownloadTest(BaseExportTest):
             reverse('calcification:rate_table_download', args=[table.pk]))
 
         expected_lines = [
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'A,2.0,1.0,3.0',
             'B,-2.0,-3.0,-1.0',
         ]
@@ -105,7 +105,7 @@ class RateTableDownloadTest(BaseExportTest):
             reverse('calcification:rate_table_download', args=[table.pk]))
 
         expected_lines = [
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'B,2.0,1.0,3.0',
             'C,-2.0,-3.0,-1.0',
         ]
@@ -133,7 +133,7 @@ class RateTableDownloadTest(BaseExportTest):
         )
 
         expected_lines = [
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             # A isn't in the labelset
             # B is in the labelset and in the table
             'B,-2.0,-3.0,-1.0',

--- a/project/calcification/tests/test_download.py
+++ b/project/calcification/tests/test_download.py
@@ -78,7 +78,7 @@ class RateTableDownloadTest(BaseExportTest):
             reverse('calcification:rate_table_download', args=[table.pk]))
 
         expected_lines = [
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'A,2.0,1.0,3.0',
             'B,-2.0,-3.0,-1.0',
         ]
@@ -105,7 +105,7 @@ class RateTableDownloadTest(BaseExportTest):
             reverse('calcification:rate_table_download', args=[table.pk]))
 
         expected_lines = [
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'B,2.0,1.0,3.0',
             'C,-2.0,-3.0,-1.0',
         ]
@@ -133,7 +133,7 @@ class RateTableDownloadTest(BaseExportTest):
         )
 
         expected_lines = [
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             # A isn't in the labelset
             # B is in the labelset and in the table
             'B,-2.0,-3.0,-1.0',

--- a/project/calcification/tests/test_export_stats.py
+++ b/project/calcification/tests/test_export_stats.py
@@ -123,7 +123,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
         # should be as expected; and should work with multiple images
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound',
+            'Mean,Lower bound,Upper bound',
 
             # 4.0*0.6 + 1.0*0.4
             # 3.2*0.6 + 0.8*0.4
@@ -153,7 +153,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
 
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound',
+            'Mean,Lower bound,Upper bound',
 
             # 4.0*0.6
             # 3.2*0.6
@@ -193,7 +193,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
             dict(rate_table_id=calcify_table_1.pk))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound',
+            'Mean,Lower bound,Upper bound',
 
             # 4.0*0.2 + 1.0*0.4
             # 3.2*0.2 + 0.8*0.4
@@ -207,7 +207,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
             dict(rate_table_id=calcify_table_2.pk))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound',
+            'Mean,Lower bound,Upper bound',
 
             # 1.5*0.4 + -3.0*0.4
             # 1.0*0.4 + -4.2*0.4
@@ -240,7 +240,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
                 optional_columns='per_label_mean'))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A M,B M,C M',
 
             # 4.0*0.6 + 1.0*0.4
@@ -261,7 +261,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
                 optional_columns='per_label_bounds'))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A LB,B LB,C LB,A UB,B UB,C UB',
 
             f'{img1.pk},1.jpg,Confirmed,5,2.800,2.240,3.400,'
@@ -282,7 +282,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
                 optional_columns=['per_label_mean', 'per_label_bounds']))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A M,B M,C M,A LB,B LB,C LB,A UB,B UB,C UB',
 
             f'{img1.pk},1.jpg,Confirmed,5,2.800,2.240,3.400,'
@@ -323,7 +323,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
         # should be as expected; and should work with multiple images
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A M,B M,C M,A LB,B LB,C LB,A UB,B UB,C UB',
 
             f'{img1.pk},1.jpg,Confirmed,5,4.000,3.200,4.800,'
@@ -368,7 +368,7 @@ class ExportTest(BaseCalcifyStatsExportTest):
                 optional_columns=['per_label_mean', 'per_label_bounds']))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A M,B M,C M,A LB,B LB,C LB,A UB,B UB,C UB',
 
             f'{img1.pk},1.jpg,Confirmed,5,4.000,3.200,4.800,'
@@ -648,7 +648,7 @@ class LabelColumnsTest(BaseCalcifyStatsExportTest):
         # Columns should have LocalLabel short codes
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             '11 M,21 M,31 M,12 M,22 M,'
             '11 LB,21 LB,31 LB,12 LB,22 LB,11 UB,21 UB,31 UB,12 UB,22 UB',
 
@@ -674,7 +674,7 @@ class LabelColumnsTest(BaseCalcifyStatsExportTest):
         # Columns should have global label names
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'A1 M,B1 M,C1 M,A2 M,B2 M,'
             'A1 LB,B1 LB,C1 LB,A2 LB,B2 LB,A1 UB,B1 UB,C1 UB,A2 UB,B2 UB',
 
@@ -718,7 +718,7 @@ class UnicodeTest(BaseCalcifyStatsExportTest):
                 optional_columns='per_label_mean'))
         expected_lines = [
             'Image ID,Image name,Annotation status,Points,'
-            'Mean rate,Lower bound,Upper bound,'
+            'Mean,Lower bound,Upper bound,'
             'い M',
 
             f'{img1.pk},あ.jpg,Confirmed,5,0.000,0.000,0.000,0.000',

--- a/project/calcification/tests/test_upload_table.py
+++ b/project/calcification/tests/test_upload_table.py
@@ -103,7 +103,7 @@ class TableUploadTest(ClientTest):
     def test_success(self):
         response = self.upload_table(
             [
-                'Label,Mean rate,Lower bound,Upper bound',
+                'Label,Mean,Lower bound,Upper bound',
                 'A,3.0,2.0,4.0',
             ],
             "Source Indo-Pacific rates",
@@ -196,7 +196,7 @@ class TableUploadTest(ClientTest):
         be matched to the expected column names.
         """
         self.upload_table([
-            'label,meaN RatE,LOWER BOUND,Upper bound',
+            'label,meaN,LOWER BOUND,Upper bound',
             'A,3.0,2.0,4.0',
         ])
 
@@ -209,7 +209,7 @@ class TableUploadTest(ClientTest):
     def test_csv_missing_column(self):
         """Should return an error when missing a required column."""
         response = self.upload_table([
-            'Label,Mean rate,Lower bound',
+            'Label,Mean,Lower bound',
             'A,3.0,2.0',
         ])
 
@@ -219,7 +219,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_unrecognized_label(self):
         response = self.upload_table([
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'F,3.0,2.0,4.0',
         ])
 
@@ -228,7 +228,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_mean_rate(self):
         response = self.upload_table([
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'A,three,2.0,4.0',
         ])
 
@@ -239,7 +239,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_lower_bound(self):
         response = self.upload_table([
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'A,3.0,two,4.0',
         ])
 
@@ -250,7 +250,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_upper_bound(self):
         response = self.upload_table([
-            'Label,Mean rate,Lower bound,Upper bound',
+            'Label,Mean,Lower bound,Upper bound',
             'A,3.0,2.0,four',
         ])
 
@@ -261,7 +261,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_required(self):
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="",
         )
 
@@ -270,7 +270,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_too_long(self):
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A"*81,
         )
 
@@ -280,11 +280,11 @@ class TableUploadTest(ClientTest):
 
     def test_name_dupe_within_source(self):
         self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
 
@@ -294,14 +294,14 @@ class TableUploadTest(ClientTest):
 
     def test_name_same_as_other_source_table(self):
         self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
 
         source2 = self.create_source(self.user)
         self.create_labelset(self.user, source2, self.labels)
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
             source=source2,
         )
@@ -313,7 +313,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_same_as_default_table(self):
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="Default Atlantic rates",
         )
 
@@ -324,7 +324,7 @@ class TableUploadTest(ClientTest):
 
     def test_description_optional(self):
         self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             description="",
         )
 
@@ -333,7 +333,7 @@ class TableUploadTest(ClientTest):
 
     def test_description_too_long(self):
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             description="A"*501,
         )
 
@@ -345,11 +345,11 @@ class TableUploadTest(ClientTest):
     def test_already_have_5_tables(self):
         for i in range(5):
             self.upload_table(
-                ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+                ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
                 name=f"Table {i}")
 
         response = self.upload_table(
-            ['Label,Mean rate,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="Another table")
 
         self.assertEqual(

--- a/project/calcification/tests/test_upload_table.py
+++ b/project/calcification/tests/test_upload_table.py
@@ -103,7 +103,7 @@ class TableUploadTest(ClientTest):
     def test_success(self):
         response = self.upload_table(
             [
-                'Label,Mean,Lower bound,Upper bound',
+                'Name,Mean,Lower bound,Upper bound',
                 'A,3.0,2.0,4.0',
             ],
             "Source Indo-Pacific rates",
@@ -196,7 +196,7 @@ class TableUploadTest(ClientTest):
         be matched to the expected column names.
         """
         self.upload_table([
-            'label,meaN,LOWER BOUND,Upper bound',
+            'name,meaN,LOWER BOUND,Upper bound',
             'A,3.0,2.0,4.0',
         ])
 
@@ -209,7 +209,7 @@ class TableUploadTest(ClientTest):
     def test_csv_missing_column(self):
         """Should return an error when missing a required column."""
         response = self.upload_table([
-            'Label,Mean,Lower bound',
+            'Name,Mean,Lower bound',
             'A,3.0,2.0',
         ])
 
@@ -219,7 +219,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_unrecognized_label(self):
         response = self.upload_table([
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'F,3.0,2.0,4.0',
         ])
 
@@ -228,7 +228,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_mean_rate(self):
         response = self.upload_table([
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'A,three,2.0,4.0',
         ])
 
@@ -239,7 +239,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_lower_bound(self):
         response = self.upload_table([
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'A,3.0,two,4.0',
         ])
 
@@ -250,7 +250,7 @@ class TableUploadTest(ClientTest):
 
     def test_csv_non_number_upper_bound(self):
         response = self.upload_table([
-            'Label,Mean,Lower bound,Upper bound',
+            'Name,Mean,Lower bound,Upper bound',
             'A,3.0,2.0,four',
         ])
 
@@ -261,7 +261,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_required(self):
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="",
         )
 
@@ -270,7 +270,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_too_long(self):
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A"*81,
         )
 
@@ -280,11 +280,11 @@ class TableUploadTest(ClientTest):
 
     def test_name_dupe_within_source(self):
         self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
 
@@ -294,14 +294,14 @@ class TableUploadTest(ClientTest):
 
     def test_name_same_as_other_source_table(self):
         self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
         )
 
         source2 = self.create_source(self.user)
         self.create_labelset(self.user, source2, self.labels)
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="A table",
             source=source2,
         )
@@ -313,7 +313,7 @@ class TableUploadTest(ClientTest):
 
     def test_name_same_as_default_table(self):
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="Default Atlantic rates",
         )
 
@@ -324,7 +324,7 @@ class TableUploadTest(ClientTest):
 
     def test_description_optional(self):
         self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             description="",
         )
 
@@ -333,7 +333,7 @@ class TableUploadTest(ClientTest):
 
     def test_description_too_long(self):
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             description="A"*501,
         )
 
@@ -345,11 +345,11 @@ class TableUploadTest(ClientTest):
     def test_already_have_5_tables(self):
         for i in range(5):
             self.upload_table(
-                ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+                ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
                 name=f"Table {i}")
 
         response = self.upload_table(
-            ['Label,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
+            ['Name,Mean,Lower bound,Upper bound', 'A,3.0,2.0,4.0'],
             name="Another table")
 
         self.assertEqual(

--- a/project/calcification/utils.py
+++ b/project/calcification/utils.py
@@ -45,7 +45,7 @@ def rate_table_csv_to_json(csv_stream):
     csv_data = csv_to_dict(
         csv_stream=csv_stream,
         required_columns=[
-            ('label_name', "Label"),
+            ('label_name', "Name"),
             ('mean', "Mean"),
             ('lower_bound', "Lower bound"),
             ('upper_bound', "Upper bound"),
@@ -86,7 +86,7 @@ def rate_table_csv_to_json(csv_stream):
 
 def rate_table_json_to_csv(csv_stream, rate_table, source=None):
     fieldnames = [
-        "Label",
+        "Name",
         "Mean",
         "Lower bound",
         "Upper bound",
@@ -115,7 +115,7 @@ def rate_table_json_to_csv(csv_stream, rate_table, source=None):
                     mean='0.0', lower_bound='0.0', upper_bound='0.0')
 
             writer.writerow({
-                "Label": label_name,
+                "Name": label_name,
                 "Mean": label_rates['mean'],
                 "Lower bound": label_rates['lower_bound'],
                 "Upper bound": label_rates['upper_bound'],
@@ -135,7 +135,7 @@ def rate_table_json_to_csv(csv_stream, rate_table, source=None):
 
         for label_id, label_rates in rates.items():
             writer.writerow({
-                "Label": label_names[label_id],
+                "Name": label_names[label_id],
                 "Mean": label_rates['mean'],
                 "Lower bound": label_rates['lower_bound'],
                 "Upper bound": label_rates['upper_bound'],

--- a/project/calcification/utils.py
+++ b/project/calcification/utils.py
@@ -46,7 +46,7 @@ def rate_table_csv_to_json(csv_stream):
         csv_stream=csv_stream,
         required_columns=[
             ('label_name', "Label"),
-            ('mean', "Mean rate"),
+            ('mean', "Mean"),
             ('lower_bound', "Lower bound"),
             ('upper_bound', "Upper bound"),
         ],
@@ -87,7 +87,7 @@ def rate_table_csv_to_json(csv_stream):
 def rate_table_json_to_csv(csv_stream, rate_table, source=None):
     fieldnames = [
         "Label",
-        "Mean rate",
+        "Mean",
         "Lower bound",
         "Upper bound",
     ]
@@ -116,7 +116,7 @@ def rate_table_json_to_csv(csv_stream, rate_table, source=None):
 
             writer.writerow({
                 "Label": label_name,
-                "Mean rate": label_rates['mean'],
+                "Mean": label_rates['mean'],
                 "Lower bound": label_rates['lower_bound'],
                 "Upper bound": label_rates['upper_bound'],
             })
@@ -136,7 +136,7 @@ def rate_table_json_to_csv(csv_stream, rate_table, source=None):
         for label_id, label_rates in rates.items():
             writer.writerow({
                 "Label": label_names[label_id],
-                "Mean rate": label_rates['mean'],
+                "Mean": label_rates['mean'],
                 "Lower bound": label_rates['lower_bound'],
                 "Upper bound": label_rates['upper_bound'],
             })

--- a/project/calcification/views.py
+++ b/project/calcification/views.py
@@ -132,15 +132,6 @@ class CalcifyStatsExportView(SourceCsvExportView):
         writer = csv.DictWriter(response, fieldnames)
         writer.writeheader()
 
-        # Limit decimal places in the final numbers.
-        def float_format(flt):
-            # Always 3 decimal places (even if the trailing places are 0).
-            s = format(flt, '.3f')
-            if s == '-0.000':
-                # Python has negative 0, but we don't care for that here.
-                return '0.000'
-            return s
-
         mean_rate_sum = 0
         lower_bound_sum = 0
         upper_bound_sum = 0
@@ -203,14 +194,15 @@ class CalcifyStatsExportView(SourceCsvExportView):
 
                 if 'per_label_mean' in optional_columns:
 
-                    row[f"{label_name} M"] = float_format(mean_contribution)
+                    row[f"{label_name} M"] = self.float_format(
+                        mean_contribution)
                     mean_contribution_sums[label_name] += mean_contribution
 
                 if 'per_label_bounds' in optional_columns:
 
-                    row[f"{label_name} LB"] = float_format(
+                    row[f"{label_name} LB"] = self.float_format(
                         lower_bound_contribution)
-                    row[f"{label_name} UB"] = float_format(
+                    row[f"{label_name} UB"] = self.float_format(
                         upper_bound_contribution)
                     lower_bound_contribution_sums[label_name] += \
                         lower_bound_contribution
@@ -218,9 +210,9 @@ class CalcifyStatsExportView(SourceCsvExportView):
                         upper_bound_contribution
 
             # Add image stats to CSV as fixed-places strings
-            row["Mean rate"] = float_format(image_mean_rate)
-            row["Lower bound"] = float_format(image_lower_bound)
-            row["Upper bound"] = float_format(image_upper_bound)
+            row["Mean rate"] = self.float_format(image_mean_rate)
+            row["Lower bound"] = self.float_format(image_lower_bound)
+            row["Upper bound"] = self.float_format(image_upper_bound)
 
             # Add to summary stats computation
             mean_rate_sum += image_mean_rate
@@ -239,18 +231,18 @@ class CalcifyStatsExportView(SourceCsvExportView):
         summary_row = {
             "Image ID": "ALL IMAGES",
             "Image name": "ALL IMAGES",
-            "Mean rate": float_format(mean_rate_sum / num_images),
-            "Lower bound": float_format(lower_bound_sum / num_images),
-            "Upper bound": float_format(upper_bound_sum / num_images),
+            "Mean rate": self.float_format(mean_rate_sum / num_images),
+            "Lower bound": self.float_format(lower_bound_sum / num_images),
+            "Upper bound": self.float_format(upper_bound_sum / num_images),
         }
         for _, label_name in label_ids_to_names.items():
             if 'per_label_mean' in optional_columns:
-                summary_row[f"{label_name} M"] = float_format(
+                summary_row[f"{label_name} M"] = self.float_format(
                     mean_contribution_sums[label_name] / num_images)
             if 'per_label_bounds' in optional_columns:
-                summary_row[f"{label_name} LB"] = float_format(
+                summary_row[f"{label_name} LB"] = self.float_format(
                     lower_bound_contribution_sums[label_name] / num_images)
-                summary_row[f"{label_name} UB"] = float_format(
+                summary_row[f"{label_name} UB"] = self.float_format(
                     upper_bound_contribution_sums[label_name] / num_images)
         writer.writerow(summary_row)
 

--- a/project/calcification/views.py
+++ b/project/calcification/views.py
@@ -101,7 +101,7 @@ class CalcifyStatsExportView(ImageStatsExportView):
     def finish_fieldnames_and_image_loop_prep(
             self, fieldnames, export_form_data):
 
-        fieldnames.extend(["Mean rate", "Lower bound", "Upper bound"])
+        fieldnames.extend(["Mean", "Lower bound", "Upper bound"])
 
         self.optional_columns = export_form_data['optional_columns']
         if 'per_label_mean' in self.optional_columns:
@@ -182,7 +182,7 @@ class CalcifyStatsExportView(ImageStatsExportView):
                     upper_bound_contribution
 
         # Add image stats to CSV as fixed-places strings
-        row["Mean rate"] = self.float_format(image_mean_rate)
+        row["Mean"] = self.float_format(image_mean_rate)
         row["Lower bound"] = self.float_format(image_lower_bound)
         row["Upper bound"] = self.float_format(image_upper_bound)
 
@@ -196,7 +196,7 @@ class CalcifyStatsExportView(ImageStatsExportView):
     def finish_summary_row(self, summary_row, num_annotated_images):
 
         summary_row.update({
-            "Mean rate": self.float_format(
+            "Mean": self.float_format(
                 self.mean_rate_sum / num_annotated_images),
             "Lower bound": self.float_format(
                 self.lower_bound_sum / num_annotated_images),

--- a/project/export/forms.py
+++ b/project/export/forms.py
@@ -73,7 +73,18 @@ class CpcPrefsForm(Form):
             self.fields[field_name].widget.attrs['size'] = str(field_size)
 
 
-class ExportImageCoversForm(Form):
-    # Stub form to make the corresponding view work.
-    # Later we'll add export options to this form though.
+class ExportImageStatsForm(Form):
+    """Form for ImageStatsExportView."""
+    label_display = ChoiceField(
+        label="Label displays in column headers",
+        choices=(
+            ('code', "Short code"),
+            ('name', "Full name"),
+        ),
+        initial='code',
+        widget=RadioSelect,
+    )
+
+
+class ExportImageCoversForm(ExportImageStatsForm):
     pass

--- a/project/export/forms.py
+++ b/project/export/forms.py
@@ -1,5 +1,6 @@
 from django.forms import Form
-from django.forms.fields import CharField, ChoiceField, MultipleChoiceField
+from django.forms.fields import (
+    CharField, ChoiceField, MultipleChoiceField)
 from django.forms.widgets import CheckboxSelectMultiple, RadioSelect
 
 
@@ -82,6 +83,18 @@ class ExportImageStatsForm(Form):
             ('name', "Full name"),
         ),
         initial='code',
+        widget=RadioSelect,
+    )
+
+    export_format = ChoiceField(
+        label="Export format",
+        choices=(
+            ('csv', "CSV"),
+            ('excel',
+             "Excel workbook with meta information"
+             " (image search filters, etc.)"),
+        ),
+        initial='csv',
         widget=RadioSelect,
     )
 

--- a/project/export/forms.py
+++ b/project/export/forms.py
@@ -71,3 +71,9 @@ class CpcPrefsForm(Form):
         )
         for field_name, field_size in field_sizes.items():
             self.fields[field_name].widget.attrs['size'] = str(field_size)
+
+
+class ExportImageCoversForm(Form):
+    # Stub form to make the corresponding view work.
+    # Later we'll add export options to this form though.
+    pass

--- a/project/export/tests/test_covers.py
+++ b/project/export/tests/test_covers.py
@@ -19,10 +19,10 @@ class PermissionTest(BasePermissionTest):
 
         self.source_to_private()
         self.assertPermissionLevel(
-            url, self.SOURCE_VIEW, content_type='text/csv')
+            url, self.SOURCE_VIEW, post_data={}, content_type='text/csv')
         self.source_to_public()
         self.assertPermissionLevel(
-            url, self.SIGNED_IN, content_type='text/csv',
+            url, self.SIGNED_IN, post_data={}, content_type='text/csv',
             deny_type=self.REQUIRE_LOGIN)
 
 

--- a/project/export/tests/test_covers.py
+++ b/project/export/tests/test_covers.py
@@ -16,58 +16,15 @@ class PermissionTest(BasePermissionTest):
 
     def test_image_covers(self):
         url = reverse('export_image_covers', args=[self.source.pk])
+        data = dict(label_display='code')
 
         self.source_to_private()
         self.assertPermissionLevel(
-            url, self.SOURCE_VIEW, post_data={}, content_type='text/csv')
+            url, self.SOURCE_VIEW, post_data=data, content_type='text/csv')
         self.source_to_public()
         self.assertPermissionLevel(
-            url, self.SIGNED_IN, post_data={}, content_type='text/csv',
+            url, self.SIGNED_IN, post_data=data, content_type='text/csv',
             deny_type=self.REQUIRE_LOGIN)
-
-
-class CalculationsTest(BaseExportTest):
-    """Test the image covers calculations."""
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = cls.create_user()
-        cls.source = cls.create_source(
-            cls.user,
-            min_x=0, max_x=100, min_y=0, max_y=100, simple_number_of_points=5)
-        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
-        cls.create_labelset(cls.user, cls.source, cls.labels)
-
-    def test_summary_row_ignores_unannotated_images(self):
-        """
-        Summary row should ignore unannotated images, so that the
-        summary percentages add up to 100.
-        """
-        img1 = self.upload_image(
-            self.user, self.source, dict(filename='1.jpg'))
-        img2 = self.upload_image(
-            self.user, self.source, dict(filename='2.jpg'))
-        self.upload_image(
-            self.user, self.source, dict(filename='3.jpg'))
-        self.add_annotations(self.user, img1, {
-            1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
-        self.add_annotations(self.user, img2, {
-            1: 'A', 2: 'B', 3: 'B', 4: 'B', 5: 'B'})
-        # None for the third image
-
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
-
-        expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
-            '2.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,20.000,80.000',
-            '3.jpg,Needs annotation,X: 0 - 100% / Y: 0 - 100%,0.000,0.000',
-            'ALL IMAGES,,,40.000,60.000',
-        ]
-        self.assert_csv_content_equal(response.content, expected_lines)
 
 
 class ImageSetTest(BaseExportTest):
@@ -86,102 +43,130 @@ class ImageSetTest(BaseExportTest):
 
     def test_all_images_single(self):
         """Export for 1 out of 1 images."""
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
 
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
+        response = self.export_image_covers(dict())
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
+            'Image ID,Image name,Annotation status,Points,A,B',
+            f'{img1.pk},1.jpg,Confirmed,5,60.000,40.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
     def test_all_images_multiple(self):
         """Export for n out of n images."""
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.img2 = self.upload_image(
+        img2 = self.upload_image(
             self.user, self.source, dict(filename='2.jpg'))
-        self.img3 = self.upload_image(
+        img3 = self.upload_image(
             self.user, self.source, dict(filename='3.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
-        self.add_annotations(self.user, self.img2, {
+        self.add_annotations(self.user, img2, {
             1: 'A', 2: 'B', 3: 'B', 4: 'B', 5: 'B'})
-        self.add_annotations(self.user, self.img3, {
+        self.add_annotations(self.user, img3, {
             1: 'A', 2: 'A', 3: 'A', 4: 'A', 5: 'A'})
 
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
+        response = self.export_image_covers(dict())
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
-            '2.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,20.000,80.000',
-            '3.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,100.000,0.000',
-            'ALL IMAGES,,,60.000,40.000',
+            'Image ID,Image name,Annotation status,Points,A,B',
+            f'{img1.pk},1.jpg,Confirmed,5,60.000,40.000',
+            f'{img2.pk},2.jpg,Confirmed,5,20.000,80.000',
+            f'{img3.pk},3.jpg,Confirmed,5,100.000,0.000',
+            'ALL IMAGES,,,,60.000,40.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
     def test_image_subset_by_metadata(self):
         """Export for some, but not all, images."""
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.img2 = self.upload_image(
+        img2 = self.upload_image(
             self.user, self.source, dict(filename='2.jpg'))
-        self.img3 = self.upload_image(
+        img3 = self.upload_image(
             self.user, self.source, dict(filename='3.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
-        self.add_annotations(self.user, self.img2, {
+        self.add_annotations(self.user, img2, {
             1: 'A', 2: 'B', 3: 'B', 4: 'B', 5: 'B'})
-        self.add_annotations(self.user, self.img3, {
+        self.add_annotations(self.user, img3, {
             1: 'A', 2: 'A', 3: 'A', 4: 'A', 5: 'A'})
-        self.img1.metadata.aux1 = 'X'
-        self.img1.metadata.save()
-        self.img2.metadata.aux1 = 'Y'
-        self.img2.metadata.save()
-        self.img3.metadata.aux1 = 'X'
-        self.img3.metadata.save()
+        img1.metadata.aux1 = 'X'
+        img1.metadata.save()
+        img2.metadata.aux1 = 'Y'
+        img2.metadata.save()
+        img3.metadata.aux1 = 'X'
+        img3.metadata.save()
 
-        post_data = self.default_search_params.copy()
-        post_data['aux1'] = 'X'
-        response = self.export_image_covers(post_data)
+        data = self.default_search_params.copy()
+        data['aux1'] = 'X'
+        response = self.export_image_covers(data)
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
-            '3.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,100.000,0.000',
-            'ALL IMAGES,,,80.000,20.000',
+            'Image ID,Image name,Annotation status,Points,A,B',
+            f'{img1.pk},1.jpg,Confirmed,5,60.000,40.000',
+            f'{img3.pk},3.jpg,Confirmed,5,100.000,0.000',
+            'ALL IMAGES,,,,80.000,20.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
     def test_image_empty_set(self):
         """Export for 0 images."""
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
 
-        post_data = self.default_search_params.copy()
-        post_data['image_name'] = '5.jpg'
-        response = self.export_image_covers(post_data)
+        data = self.default_search_params.copy()
+        data['image_name'] = '5.jpg'
+        response = self.export_image_covers(data)
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
+            'Image ID,Image name,Annotation status,Points,A,B',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_exclude_unannotated_images(self):
+        """
+        CSV should exclude unannotated images, regardless of whether the
+        search filters include such images.
+        """
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        img2 = self.upload_image(
+            self.user, self.source, dict(filename='2.jpg'))
+        self.upload_image(
+            self.user, self.source, dict(filename='3.jpg'))
+        # 1st image confirmed
+        self.add_annotations(self.user, img1, {
+            1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
+        # 2nd image unconfirmed
+        robot = self.create_robot(self.source)
+        self.add_robot_annotations(robot, img2, {
+            1: 'A', 2: 'B', 3: 'B', 4: 'B', 5: 'B'})
+        # 3rd image unannotated
+
+        response = self.export_image_covers(dict())
+
+        expected_lines = [
+            'Image ID,Image name,Annotation status,Points,A,B',
+            f'{img1.pk},1.jpg,Confirmed,5,60.000,40.000',
+            f'{img2.pk},2.jpg,Unconfirmed,5,20.000,80.000',
+            'ALL IMAGES,,,,40.000,60.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
     def test_invalid_image_set_params(self):
         self.upload_image(self.user, self.source)
 
-        post_data = self.default_search_params.copy()
-        post_data['photo_date_0'] = 'abc'
-        response = self.export_image_covers(post_data)
+        data = self.default_search_params.copy()
+        data['photo_date_0'] = 'abc'
+        response = self.export_image_covers(data)
 
         # Display an error in HTML instead of serving CSV.
         self.assertTrue(response['content-type'].startswith('text/html'))
@@ -189,9 +174,9 @@ class ImageSetTest(BaseExportTest):
 
     def test_dont_get_other_sources_images(self):
         """Don't export for other sources' images."""
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
 
         source2 = self.create_source(self.user, simple_number_of_points=5)
@@ -200,19 +185,18 @@ class ImageSetTest(BaseExportTest):
         self.add_annotations(self.user, img2, {
             1: 'A', 2: 'B', 3: 'A', 4: 'B', 5: 'A'})
 
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
+        response = self.export_image_covers(dict())
 
         # Should have image 1, but not 2
         expected_lines = [
-            'Name,Annotation status,Annotation area,A,B',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,60.000,40.000',
+            'Image ID,Image name,Annotation status,Points,A,B',
+            f'{img1.pk},1.jpg,Confirmed,5,60.000,40.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
 
-class ColumnOrderTest(BaseExportTest):
-    """Test column order in the exported covers CSV."""
+class LabelColumnsTest(BaseExportTest):
+    """Test naming and ordering of the per-label CSV columns."""
 
     @classmethod
     def setUpTestData(cls):
@@ -222,37 +206,64 @@ class ColumnOrderTest(BaseExportTest):
         cls.source = cls.create_source(
             cls.user,
             min_x=0, max_x=100, min_y=0, max_y=100, simple_number_of_points=5)
-        labels = cls.create_labels(cls.user, ['A', 'B', 'C'], 'GroupA')
-        cls.create_labelset(cls.user, cls.source, labels)
+        # To test ordering by group and then name/code, we'll stagger the
+        # alphabetical ordering between two label groups.
+        labels_a = cls.create_labels(cls.user, ['A1', 'B1', 'C1'], 'Group1')
+        labels_b = cls.create_labels(cls.user, ['A2', 'B2'], 'Group2')
+        cls.create_labelset(cls.user, cls.source, labels_a | labels_b)
 
         # Custom codes; ordering by these codes gives a different order from
-        # ordering by name or default code
+        # ordering by name or default code. Again, alpha order is staggered
+        # between groups.
         local_a = LocalLabel.objects.get(
-            labelset=cls.source.labelset, code='A')
-        local_a.code = '2'
+            labelset=cls.source.labelset, code='A1')
+        local_a.code = '21'
         local_a.save()
         local_b = LocalLabel.objects.get(
-            labelset=cls.source.labelset, code='B')
-        local_b.code = '1'
+            labelset=cls.source.labelset, code='B1')
+        local_b.code = '31'
         local_b.save()
         local_c = LocalLabel.objects.get(
-            labelset=cls.source.labelset, code='C')
-        local_c.code = '3'
+            labelset=cls.source.labelset, code='C1')
+        local_c.code = '11'
         local_c.save()
 
-    def test(self):
-        self.img1 = self.upload_image(
+        local_d = LocalLabel.objects.get(
+            labelset=cls.source.labelset, code='A2')
+        local_d.code = '22'
+        local_d.save()
+        local_e = LocalLabel.objects.get(
+            labelset=cls.source.labelset, code='B2')
+        local_e.code = '12'
+        local_e.save()
+
+    def test_order_by_group_and_code(self):
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='1.jpg'))
-        self.add_annotations(self.user, self.img1, {
-            1: '3', 2: '1', 3: '2', 4: '1', 5: '3'})
+        self.add_annotations(self.user, img1, {
+            1: '21', 2: '31', 3: '31', 4: '22', 5: '12'})
 
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
+        response = self.export_image_covers(dict())
 
-        # Columns should be ordered by LocalLabel short code
+        # Columns should have LocalLabel short codes
         expected_lines = [
-            'Name,Annotation status,Annotation area,1,2,3',
-            '1.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,40.000,20.000,40.000',
+            'Image ID,Image name,Annotation status,Points,11,21,31,12,22',
+            f'{img1.pk},1.jpg,Confirmed,5,0.000,20.000,40.000,20.000,20.000',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_order_by_group_and_name(self):
+        img1 = self.upload_image(
+            self.user, self.source, dict(filename='1.jpg'))
+        self.add_annotations(self.user, img1, {
+            1: '21', 2: '31', 3: '31', 4: '22', 5: '12'})
+
+        response = self.export_image_covers(dict(label_display='name'))
+
+        # Columns should have global label names
+        expected_lines = [
+            'Image ID,Image name,Annotation status,Points,A1,B1,C1,A2,B2',
+            f'{img1.pk},1.jpg,Confirmed,5,20.000,40.000,0.000,20.000,20.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 
@@ -277,16 +288,15 @@ class UnicodeTest(BaseExportTest):
         local_label.save()
 
     def test(self):
-        self.img1 = self.upload_image(
+        img1 = self.upload_image(
             self.user, self.source, dict(filename='あ.jpg'))
-        self.add_annotations(self.user, self.img1, {
+        self.add_annotations(self.user, img1, {
             1: 'い', 2: 'い', 3: 'い', 4: 'い', 5: 'い'})
 
-        post_data = self.default_search_params.copy()
-        response = self.export_image_covers(post_data)
+        response = self.export_image_covers(dict())
 
         expected_lines = [
-            'Name,Annotation status,Annotation area,い',
-            'あ.jpg,Confirmed,X: 0 - 100% / Y: 0 - 100%,100.000',
+            'Image ID,Image name,Annotation status,Points,い',
+            f'{img1.pk},あ.jpg,Confirmed,5,100.000',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)

--- a/project/export/tests/utils.py
+++ b/project/export/tests/utils.py
@@ -31,16 +31,6 @@ class BaseExportTest(ClientTest):
             resolve_url('export_annotations', self.source.pk), post_data,
             follow=True)
 
-    def export_image_covers(self, post_data):
-        """POST to export_image_covers, and return the response."""
-        if 'label_display' not in post_data:
-            post_data['label_display'] = 'code'
-
-        self.client.force_login(self.user)
-        return self.client.post(
-            resolve_url('export_image_covers', self.source.pk), post_data,
-            follow=True)
-
     def export_metadata(self, post_data):
         """POST to export_metadata, and return the response."""
         self.client.force_login(self.user)

--- a/project/export/tests/utils.py
+++ b/project/export/tests/utils.py
@@ -33,6 +33,9 @@ class BaseExportTest(ClientTest):
 
     def export_image_covers(self, post_data):
         """POST to export_image_covers, and return the response."""
+        if 'label_display' not in post_data:
+            post_data['label_display'] = 'code'
+
         self.client.force_login(self.user)
         return self.client.post(
             resolve_url('export_image_covers', self.source.pk), post_data,

--- a/project/export/urls.py
+++ b/project/export/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
          views.export_annotations_cpc_serve,
          name="export_annotations_cpc_serve"),
     path('image_covers/',
-         views.export_image_covers, name="export_image_covers"),
+         views.ImageCoversExportView.as_view(), name="export_image_covers"),
     path('labelset/',
          views.export_labelset, name="export_labelset"),
 ]

--- a/project/export/utils.py
+++ b/project/export/utils.py
@@ -28,9 +28,11 @@ def get_request_images(request, source):
             # worked for the Browse-images page load, but not for the
             # subsequent export.
             raise ValidationError("Image-search parameters were invalid.")
+        applied_search_display = image_form.get_applied_search_display()
     else:
         image_set = source.image_set.order_by('metadata__name', 'pk')
-    return image_set
+        applied_search_display = "Sorting by name, ascending"
+    return image_set, applied_search_display
 
 
 def create_stream_response(content_type, filename):

--- a/project/export/views.py
+++ b/project/export/views.py
@@ -198,7 +198,8 @@ class ImageStatsExportView(SourceCsvExportView, ABC):
         writer.writeheader()
 
         # One row per image
-        for image in image_set.select_related('annoinfo', 'metadata') \
+        for image in image_set \
+                .select_related('annoinfo', 'features', 'metadata') \
                 .annotate(num_points=Count('point')):
 
             if image.get_annotation_status_code() == 'needs_annotation':

--- a/project/export/views.py
+++ b/project/export/views.py
@@ -47,7 +47,15 @@ class SourceCsvExportView(View):
     def write_csv(self, response, source, image_set, export_form_data):
         raise NotImplementedError
 
-    def get(self, request, source_id):
+    def post(self, request, source_id):
+        """
+        We define these views as POST, not GET, because we want to save
+        database stats for some of the source-level exports.
+
+        Also, none of the advantages of GET particularly apply to these
+        export views (bookmarking the URL, bots indexing the response,
+        avoiding browser resend warnings on Back/Refresh, etc.)
+        """
         source = get_object_or_404(Source, id=source_id)
 
         try:
@@ -57,7 +65,7 @@ class SourceCsvExportView(View):
             return HttpResponseRedirect(
                 reverse('browse_images', args=[source_id]))
 
-        export_form = self.get_export_form(source, request.GET)
+        export_form = self.get_export_form(source, request.POST)
         if not export_form.is_valid():
             messages.error(request, get_one_form_error(export_form))
             return HttpResponseRedirect(

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -484,9 +484,12 @@ class CalcificationRatesTest(ClientTest):
         The calcification rates help dialog should have download links to the
         latest default tables.
         """
-        atlantic_table = create_default_calcify_table(
+        atlantic_table_1 = create_default_calcify_table(
             'Atlantic', {
                 self.label_b.pk: dict(mean=2, lower_bound=1, upper_bound=3)})
+        atlantic_table_2 = create_default_calcify_table(
+            'Atlantic', {
+                self.label_b.pk: dict(mean=2, lower_bound=0.8, upper_bound=3)})
         indo_pacific_table = create_default_calcify_table(
             'Indo-Pacific', {
                 self.label_a.pk: dict(mean=5, lower_bound=4, upper_bound=6),
@@ -496,14 +499,22 @@ class CalcificationRatesTest(ClientTest):
         response_soup = BeautifulSoup(response.content, 'html.parser')
         help_dialog_tag = response_soup.select('div.tutorial-message')[0]
 
-        atlantic_download_url = reverse(
-            'calcification:rate_table_download', args=[atlantic_table.pk])
+        atlantic_1_download_url = reverse(
+            'calcification:rate_table_download', args=[atlantic_table_1.pk])
+        atlantic_2_download_url = reverse(
+            'calcification:rate_table_download', args=[atlantic_table_2.pk])
         indo_pacific_download_url = reverse(
             'calcification:rate_table_download', args=[indo_pacific_table.pk])
-        self.assertInHTML(
-            f'<a href="{atlantic_download_url}">Atlantic</a>',
+
+        # Latest Atlantic table only, and Indo-Pacific table
+        self.assertNotIn(
+            atlantic_1_download_url,
             str(help_dialog_tag),
-            msg_prefix="Atlantic table download link should be present")
+            msg="Atlantic table 1 download link should be absent")
+        self.assertInHTML(
+            f'<a href="{atlantic_2_download_url}">Atlantic</a>',
+            str(help_dialog_tag),
+            msg_prefix="Atlantic table 2 download link should be present")
         self.assertInHTML(
             f'<a href="{indo_pacific_download_url}">Indo-Pacific</a>',
             str(help_dialog_tag),

--- a/project/visualization/templates/visualization/browse_images.html
+++ b/project/visualization/templates/visualization/browse_images.html
@@ -155,7 +155,8 @@
         </form>
 
         <form action="{% url 'calcification:stats_export' source.pk %}"
-        method="get" id="export-calcify-rates-form">
+        method="post" id="export-calcify-rates-form">
+          {% csrf_token %}
           <hr/>
           <span class="image-select-field-container"></span>
 

--- a/project/visualization/templates/visualization/browse_images.html
+++ b/project/visualization/templates/visualization/browse_images.html
@@ -151,6 +151,9 @@
         id="export-image-covers-form">
           {% csrf_token %}
           <span class="image-select-field-container"></span>
+
+          {% include "form_generic.html" with form=export_image_covers_form %}
+
           <button type="button" class="submit">Go</button>
         </form>
 

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -64,7 +64,7 @@
     </ul>
   </li>
 
-  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, image 0001.JPG consists of 5% Acropora, 10% Porites, etc. based on the annotations. Also included is the image's "annotation area", which is the area of the image where the random points are scattered. The "ALL IMAGES" summary row at the end shows the average stats over all images with annotations, with each image being weighted equally.</li>
+  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, image 0001.JPG consists of 5% Acropora, 10% Porites, etc. based on the annotations. The "ALL IMAGES" summary row at the end shows the average stats for the image set, with each image being weighted equally. Unannotated images are excluded from the analysis.</li>
 
   <li><strong>Calcification Rates:</strong> Calcification rates for each image in the set. For example, image 0001.JPG's calcification rates are: mean 4.8, lower bound 3.2, upper bound 6.0. The rates are computed based on the image's annotations, and the calcification rates specified for each label (you must pick a label rate table to use). There are optional sets of columns available:
 
@@ -74,7 +74,7 @@
       <li>Per-label contributions to confidence bounds: This shows the per-label breakdowns for the lower bound and upper bound rate calculations. These columns will be named like "Acropora LB", "Porites LB", "Acropora UB", "Porites UB", etc.</li>
     </ul>
 
-    An "ALL IMAGES" summary row is included as the last row. This summary averages the stats over all the images, with each image being weighted equally (regardless of the number of point annotations).
+    The "ALL IMAGES" summary row at the end shows the average stats over all the images, with each image being weighted equally. Unannotated images are excluded from the analysis.
   </li>
 </ul>
 

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -74,7 +74,7 @@
       <li>Per-label contributions to confidence bounds: This shows the per-label breakdowns for the lower bound and upper bound rate calculations. These columns will be named like "Acropora LB", "Porites LB", "Acropora UB", "Porites UB", etc.</li>
     </ul>
 
-    The "ALL IMAGES" summary row at the end shows the average stats over all the images, with each image being weighted equally. Unannotated images are excluded from the analysis.
+    The "ALL IMAGES" summary row at the end shows the average stats over all the images, with each image being weighted equally. Unannotated images are excluded from the analysis. If you choose to export an Excel workbook instead of CSV, it will include a sheet with the label rate table you chose.
   </li>
 </ul>
 

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -64,7 +64,7 @@
     </ul>
   </li>
 
-  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, image 0001.JPG consists of 5% Acropora, 10% Porites, etc. based on the annotations. Also included is the image's "annotation area", which is the area of the image where the random points are scattered.</li>
+  <li><strong>Image Covers:</strong> Coverage statistics for each image in the set; for example, image 0001.JPG consists of 5% Acropora, 10% Porites, etc. based on the annotations. Also included is the image's "annotation area", which is the area of the image where the random points are scattered. The "ALL IMAGES" summary row at the end shows the average stats over all images with annotations, with each image being weighted equally.</li>
 
   <li><strong>Calcification Rates:</strong> Calcification rates for each image in the set. For example, image 0001.JPG's calcification rates are: mean 4.8, lower bound 3.2, upper bound 6.0. The rates are computed based on the image's annotations, and the calcification rates specified for each label (you must pick a label rate table to use). There are optional sets of columns available:
 

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -14,7 +14,8 @@ from accounts.utils import get_robot_user
 from annotations.models import Annotation
 from calcification.forms import CalcifyRateTableForm, ExportCalcifyStatsForm
 from calcification.utils import get_default_calcify_tables
-from export.forms import CpcPrefsForm, ExportAnnotationsForm
+from export.forms import (
+    CpcPrefsForm, ExportAnnotationsForm, ExportImageCoversForm)
 from export.utils import get_previous_cpcs_status
 from images.forms import MetadataFormForGrid, BaseMetadataFormSet
 from images.models import Source, Image, Metadata
@@ -90,6 +91,7 @@ def browse_images(request, source_id):
         'links': links,
         'hidden_image_form': hidden_image_form,
         'export_annotations_form': ExportAnnotationsForm(),
+        'export_image_covers_form': ExportImageCoversForm(),
 
         'export_calcify_rates_form': ExportCalcifyStatsForm(source=source),
         'calcify_table_form': CalcifyRateTableForm(source=source),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,14 @@ Pillow==8.2.0
 # Changelog: https://piexif.readthedocs.io/en/latest/changes.html
 piexif==1.1.3
 
+# Working with Excel and other spreadsheet formats.
+# Changelog: https://github.com/pyexcel/pyexcel/blob/dev/CHANGELOG.rst
+pyexcel==0.6.6
+
+# xlsx support in pyexcel.
+# Changelog: https://github.com/pyexcel/pyexcel-xlsx/blob/dev/CHANGELOG.rst
+pyexcel-xlsx==0.6.0
+
 # Web requests.
 # Changelog: https://github.com/psf/requests/blob/master/HISTORY.md
 requests==2.25.1


### PR DESCRIPTION
- Did the image covers part of #373
- Did #374 (added the `pyexcel` and `pyexcel-xlsx` packages for this)
- Made image-info columns consistent between image covers / calcification rates exports
- A bit of database performance improvement for image covers / calcification rates exports (did not touch annotations export, which is still super slow)