### PR TITLE
CPCe upload/export: Add option to map label codes to ID+Notes

### DIFF
--- a/project/export/views.py
+++ b/project/export/views.py
@@ -337,7 +337,7 @@ def export_annotations_cpc_create_ajax(request, source_id):
             error=e.message
         ))
 
-    cpc_prefs_form = CpcPrefsForm(request.POST)
+    cpc_prefs_form = CpcPrefsForm(source, request.POST)
     if not cpc_prefs_form.is_valid():
         return JsonResponse(dict(
             error=get_one_form_error(cpc_prefs_form),

--- a/project/labels/utils.py
+++ b/project/labels/utils.py
@@ -54,3 +54,12 @@ def is_label_editable_by_user(label, user):
     # The user is admin of all 1+ sources using this label, and the label
     # isn't verified; OK to edit
     return True
+
+
+def labelset_has_plus_code(labelset):
+    """
+    Returns True if the labelset has at least one label code with the
+    + character, False otherwise. This is for CPCe upload/export.
+    (TODO: It'd be better to create a 'cpce' app and move this function there.)
+    """
+    return labelset.get_labels().filter(code__contains='+').exists()

--- a/project/upload/static/js/UploadAnnotationsCPCHelper.js
+++ b/project/upload/static/js/UploadAnnotationsCPCHelper.js
@@ -272,6 +272,7 @@ var UploadAnnotationsCPCHelper = (function() {
             // Form and field elements.
             $cpcForm = $('#cpc_form');
             cpcFileField = $('#id_cpc_files')[0];
+            plusNotesField = $('#id_plus_notes')[0];
 
             // Button elements.
             $uploadStartButton = $('#id_upload_submit');
@@ -279,6 +280,9 @@ var UploadAnnotationsCPCHelper = (function() {
 
             // Handlers.
             $(cpcFileField).change(function() {
+                updateUploadPreview();
+            });
+            $(plusNotesField).change(function() {
                 updateUploadPreview();
             });
             $uploadStartButton.click(function() {

--- a/project/upload/templates/upload/upload_annotations_cpc.html
+++ b/project/upload/templates/upload/upload_annotations_cpc.html
@@ -25,7 +25,10 @@
         {% csrf_token %}
 
         {% with cpc_import_form.cpc_files as field %}
-          {{ field.label }}: {{ field }}
+          <div class="line">{{ field.label }}: {{ field }}</div>
+        {% endwith %}
+        {% with cpc_import_form.plus_notes as field %}
+          <div class="line">{{ field }} {{ field.label }}</div>
         {% endwith %}
 
         <div class="tutorial-message">

--- a/project/upload/templates/upload/upload_annotations_cpc_help.html
+++ b/project/upload/templates/upload/upload_annotations_cpc_help.html
@@ -21,6 +21,8 @@
   </li>
 </ul>
 
-<p>CPC files contain other information besides points and labels, such as header data and notes codes. When you upload CPC files, CoralNet retains this information on a per-image basis, and you can get this information back by exporting annotations to CPC format. (The Export feature is available at the bottom of the "Images" page.)</p>
+<p><strong>Support CPCe Notes codes using + as a separator</strong>: CPCe's interface has two fields for each point, "ID" and "Notes". Normally, we just take the ID as the label code to save in CoralNet. However, if this checkbox is checked, we instead combine the ID and Notes codes to form the label code for CoralNet. For example, if the ID field has "ROCK" and the Notes field as "TURF", then the CoralNet label code is taken to be "ROCK+TURF". Note that this only works if your source's labelset has an entry with the short code "ROCK+TURF". Also keep in mind that CoralNet short codes can't be more than 10 characters long.</p>
+
+<p>CPC files contain other information besides point locations, ID, and Notes - such as header data. When you upload CPC files, CoralNet retains this information on a per-image basis, and you can get this information back by exporting annotations to CPC format. (The Export feature is available at the bottom of the "Images" page.)</p>
 
 </div>

--- a/project/upload/views.py
+++ b/project/upload/views.py
@@ -344,7 +344,7 @@ def upload_annotations_csv_preview_ajax(request, source_id):
 def upload_annotations_cpc(request, source_id):
     source = get_object_or_404(Source, id=source_id)
 
-    cpc_import_form = CPCImportForm()
+    cpc_import_form = CPCImportForm(source)
 
     return render(request, 'upload/upload_annotations_cpc.html', {
         'source': source,
@@ -370,7 +370,7 @@ def upload_annotations_cpc_preview_ajax(request, source_id):
 
     source = get_object_or_404(Source, id=source_id)
 
-    cpc_import_form = CPCImportForm(request.POST, request.FILES)
+    cpc_import_form = CPCImportForm(source, request.POST, request.FILES)
     if not cpc_import_form.is_valid():
         return JsonResponse(dict(
             error=cpc_import_form.errors['cpc_files'][0],
@@ -378,7 +378,8 @@ def upload_annotations_cpc_preview_ajax(request, source_id):
 
     try:
         cpc_info = annotations_cpcs_to_dict(
-            cpc_import_form.get_cpc_names_and_streams(), source)
+            cpc_import_form.get_cpc_names_and_streams(), source,
+            cpc_import_form.cleaned_data['plus_notes'])
     except FileProcessError as error:
         return JsonResponse(dict(
             error=str(error),

--- a/project/visualization/templates/visualization/browse_images.html
+++ b/project/visualization/templates/visualization/browse_images.html
@@ -237,6 +237,8 @@
               {% include "form_generic_one_field.html" with field=cpc_prefs_form.local_image_dir %}
             {% endif %}
 
+            {% include "form_generic_one_field.html" with field=cpc_prefs_form.plus_notes checkbox='yes' %}
+
             <button type="button" class="submit">Go</button>
           </form>
 

--- a/project/visualization/templates/visualization/help_browse_actions.html
+++ b/project/visualization/templates/visualization/help_browse_actions.html
@@ -47,7 +47,19 @@
     The .cpc file format contains several pieces of information besides point positions and labels; here's how we handle each one:
 
     <ul>
-      <li>Notes codes: Coral Point Count has a Notes column in the list of points. If a particular CoralNet image has a .cpc file saved, that .cpc file's Notes codes will be retained. If the image does not have a .cpc file saved, the Notes codes will be blank.</li>
+      <li>Notes codes: CPCe's interface has two fields for each point, "ID" and "Notes". Treatment of the Notes field depends on whether the "Support CPCe Notes codes using + as a separator" checkbox is checked.
+        <ul>
+          <li>If the checkbox is checked, we split up the CoralNet label code on the + symbol to get the ID and Notes codes. For example, if the CoralNet label code is "ROCK+TURF", then the exported .cpc file has ID of "ROCK" and Notes of "TURF" for the corresponding point. If the CoralNet label code is just "ROCK", then the .cpc gets ID of "ROCK" and a blank Notes field.</li>
+
+          <li>If the checkbox is unchecked, the CoralNet label codes will only be mapped to the .cpc ID fields, and here is what happens with the Notes codes:
+            <ul>
+              <li>If a particular CoralNet image has a .cpc file saved, that .cpc file's Notes codes will be retained.</li>
+
+              <li>If the image does not have a .cpc file saved, the Notes codes will be blank.</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
 
       <li>Header data: When you create a .cpc file in Coral Point Count (at least in CPCe 4.1), at some point it shows a window with 28 header fields such as Project name, Site name, Latitude, Easting, etc. If a particular CoralNet image has a .cpc file saved, that .cpc file's header values will be retained. Otherwise, we will fill in blank header values. (You might notice that these header fields have some overlap with CoralNet's metadata fields, but CoralNet does not make any connection between these two sets of fields on import/export.)</li>
 


### PR DESCRIPTION
This will be our way to support CPCe Notes codes for the time being (before we can implement multiple labels per point in CoralNet).