### PR TITLE
Edit Source: confidence threshold widget fixes

### DIFF
--- a/project/images/forms.py
+++ b/project/images/forms.py
@@ -44,7 +44,8 @@ class ImageSourceForm(ModelForm):
             'longitude', 'latitude',
         ]
         widgets = {
-            'confidence_threshold': NumberInput(attrs={'size': 2}),
+            'confidence_threshold': NumberInput(
+                attrs={'min': 0, 'max': 100, 'size': 3}),
             'longitude': TextInput(attrs={'size': 10}),
             'latitude': TextInput(attrs={'size': 10}),
         }


### PR DESCRIPTION
Add min/max and a more usable size. This didn't affect server-side field validation, it just affected the interactivity of the form field.

I would have liked the min/max to carry over automatically from the model field, but that doesn't seem to happen for integer fields (unlike max length for char fields).