### PR TITLE
API job monitoring fixes

### DIFF
--- a/project/api_management/tests.py
+++ b/project/api_management/tests.py
@@ -148,7 +148,7 @@ class JobDetailTest(ClientTest):
             points=[dict(row=20, column=30), dict(row=40, column=50)],
         )
         cls.sample_result_json_with_error = dict(
-            error="Error goes here",
+            errors=["Error goes here"],
         )
 
     def test_all_table_columns(self):

--- a/project/api_management/views.py
+++ b/project/api_management/views.py
@@ -55,10 +55,11 @@ def job_detail(request, job_id):
         # job types later, then this code has to become more flexible.
         request_json_strings = deploy_request_json_as_strings(unit_obj)
 
+        error_display = ''
         if unit_obj.result_json:
-            error_display = unit_obj.result_json.get('error', '')
-        else:
-            error_display = ''
+            errors = unit_obj.result_json.get('errors')
+            if errors:
+                error_display = errors[0]
 
         units.append(dict(
             id=unit_obj.pk,

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -386,6 +386,15 @@ def warn_about_stuck_jobs():
         .filter(create_date__lt=five_days_ago, create_date__gt=six_days_ago) \
         .exclude(status='SUCCEEDED') \
         .exclude(status='FAILED')
+
+    if not stuck_jobs_between_5_and_6_days_old.exists():
+        return
+
+    stuck_job_count = stuck_jobs_between_5_and_6_days_old.count()
+    subject = f"{stuck_job_count} AWS Batch job(s) not completed after 5 days"
+
+    message = "The following AWS Batch jobs were not completed after 5 days:\n"
     for job in stuck_jobs_between_5_and_6_days_old:
-        mail_admins("Job {} not completed after 5 days.".format(
-            job.batch_token), str(job))
+        message += f"\n{job}"
+
+    mail_admins(subject, message)


### PR DESCRIPTION
- In the daily `warn_about_stuck_jobs()` task, only send one email listing all the stuck jobs, rather than one email per stuck job.
- In the API job detail page, fix the job unit error display; the dict key changed from `error` to `errors` at some point.