### PR TITLE
Add 2022 calcification paper to the About page

### DIFF
--- a/project/lib/templates/lib/about.html
+++ b/project/lib/templates/lib/about.html
@@ -218,6 +218,12 @@
     </p>
     <ul>
         <li><p>
+            T. Courtney, H. Barkley, S. Chan, C. Couch, T. Kindinger, T. Oliver, D. Kriegman, A. Andersson.
+            <i><a href="https://aslopubs.onlinelibrary.wiley.com/doi/abs/10.1002/lno.12159">
+                "Rapid assessments of Pacific Ocean net coral reef carbonate budgets and net calcification following the 2014-2017 global coral bleaching event"</a></i>.
+            Limnology and Oceanography, June 24, 2022.
+        </p></li>
+        <li><p>
             Q. Chen, O. Beijbom, S. Chan, J. Bouwmeester, D. Kriegman.
             <i><a href="https://openaccess.thecvf.com/content/ICCV2021W/OceanVision/papers/Chen_A_New_Deep_Learning_Engine_for_CoralNet_ICCVW_2021_paper.pdf">
                 "A New Deep Learning Engine for CoralNet"</a></i>.


### PR DESCRIPTION
For the moment, this will go live in production through the `about-2022-paper-backport` branch which doesn't have the new async-Jobs code yet, since I'm not ready to pull the async-Jobs code into production yet.