### PR TITLE
More docs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 
-For general instructions on how to update a development environment of CoralNet, see "Server operation" > "Updating to the latest repository code" under `/docs`. This changelog has specific instructions/notes for each CoralNet version.
+For general instructions on how to update a development environment of CoralNet, see "Updating to the latest repository code" in `docs/server_operation.rst`. This changelog has specific instructions/notes for each CoralNet version.
+
+For info about the semantic versioning used here, see `docs/versions.rst`.
 
 
 ## [1.5](https://github.com/beijbom/coralnet/tree/1.5)

--- a/docs/design/browser-compatibility.rst
+++ b/docs/design/browser-compatibility.rst
@@ -1,7 +1,7 @@
 Browser compatibility
 =====================
 
-The tables largely excludes old Firefox/Chrome versions, old mobile browser versions, and Internet Explorer 6 or earlier (`IE 6 usage info <https://developer.microsoft.com/en-us/microsoft-edge/ie6countdown/>`__).
+The tables largely excludes old Firefox/Chrome versions, old mobile browser versions, and `Internet Explorer <https://blogs.windows.com/windowsexperience/2022/06/15/internet-explorer-11-has-retired-and-is-officially-out-of-support-what-you-need-to-know/>`__.
 
 Although we tend to recommend the latest Firefox/Chrome, we should still weigh support of other browsers versus the usefulness of a particular feature.
 
@@ -12,42 +12,21 @@ If you want your code to check that the user's browser supports a particular fea
    * - Feature used on CoralNet
      - Incompatible browsers
      - Usage notes
-   * - `addEventListener() <http://caniuse.com/#feat=addeventlistener>`__
-     - IE 8
-     - See `this page <https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener>`__ for an explanation of why this is preferred over attributes like ``onclick``.
-   * - `Border-radius <http://caniuse.com/#feat=border-radius>`__
-     - Opera Mini, IE 8
-     - Not a big deal if some elements don't have rounded corners
-   * - `Canvas <http://caniuse.com/#search=canvas>`__
-     - IE 8
-     - No animations used. Annotation tool heavily depends on canvas.
-   * - `Child selector <http://caniuse.com/#feat=css-sel2>`__ ``a > b``
-     - (None)
+   * - `Arrow functions <https://caniuse.com/#feat=arrow-functions>`__
+     - IE 11, Samsung Internet 4, Opera Mini
+     - Example use: `Using forEach() slightly more concisely <https://stackoverflow.com/a/40364002/>`__
+   * - `ES6 Classes <https://caniuse.com/#feat=es6-class>`__
+     - IE 11, Samsung Internet 4, Opera Mini
      -
-   * - `Colors, CSS3 <http://caniuse.com/#feat=css3-colors>`__
-     - IE 8
-     - ``hsl()`` and ``rgba()`` are used in some places
-   * - `Data URIs <http://caniuse.com/#feat=datauri>`__
-     - IE 7
-     - For lazy-loading of images
-   * - `:first-child selector <http://caniuse.com/#feat=css-sel2>`__
-     - (None)
-     -
-   * - `File selection, multiple <http://caniuse.com/#feat=input-file-multiple>`__
-     - Android, IE Mobile, Opera Mini, IE 9
-     - These browsers should still be able to upload single files on these pages
-   * - `Flexbox <http://caniuse.com/#feat=flexbox>`__
-     - Safari 8, IE 10
-     - Single usage of ``display: flex; align-items: center;`` in map code. Used without ``webkit-`` prefix. (2016.11)
-   * - `forEach() <https://caniuse.com/#feat=es5>`__
-     - IE 8
-     - Replaces the old array for-loop syntax of ``for (i = 0; i < arr.length; i++)``
-   * - `input type="number" <http://caniuse.com/#feat=input-number>`__
-     - iOS Safari, Android, Chrome for Android, Opera Mini, IE 9
-     - Not necessarily broken if not supported, just less robust against arbitrary input.
-   * - `:not selector <http://caniuse.com/#feat=css-sel3>`__
-     - Safari 3.1, IE 8
-     -
+   * - `ES6 Template Literals (Template Strings) <https://caniuse.com/#feat=template-literals>`__
+     - IE 11, Opera Mini, UC Browser for Android
+     - Our best alternative is ``String.prototype.format()`` defined in ``util.js``
+   * - `for...of <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of>`__
+     - IE 11
+     - Don't need the hasOwnProperty() check with this, unlike for...in
+   * - `Promises <https://caniuse.com/#feat=promises>`__
+     - IE 11, Opera Mini
+     - For asynchronous code
 
 Here are some features that aren't yet used, but are fairly likely to be used eventually.
 
@@ -56,24 +35,6 @@ Here are some features that aren't yet used, but are fairly likely to be used ev
    * - Feature not used on CoralNet (yet)
      - Incompatible browsers
      - Usage notes
-   * - `Arrow functions <https://caniuse.com/#feat=arrow-functions>`__
-     - IE 11, Samsung Internet 4, Opera Mini
-     - Example use: `Using forEach() slightly more concisely <https://stackoverflow.com/a/40364002/>`__
-   * - `ES6 Classes <https://caniuse.com/#feat=es6-class>`__
-     - IE 11, Samsung Internet 4, Opera Mini
-     -
    * - `ES6 Generators <https://caniuse.com/#feat=es6-generators>`__
      - IE 11, Opera Mini
      - Useful for `asynchronous code <http://exploringjs.com/es6/ch_generators.html#sec_overview-generators>`__
-   * - `ES6 Template Literals (Template Strings) <https://caniuse.com/#feat=template-literals>`__
-     - IE 11, Opera Mini, UC Browser for Android
-     - Our best alternative is ``String.prototype.format()`` defined in ``util.js``
-   * - `for...of <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of>`__
-     - IE 11
-     - Don't need the hasOwnProperty() check with this, unlike for...in
-   * - `let (variable declaration) <https://caniuse.com/#feat=let>`__
-     - Opera Mini
-     -
-   * - `Promises <https://caniuse.com/#feat=promises>`__
-     - IE 11, Opera Mini
-     - For asynchronous code

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Contents:
 
    installation
    server-operation
-   release
+   versions
    design/index
 
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -1,6 +1,8 @@
-Releases and semantic versioning
-================================
+Semantic versioning
+===================
 
+
+CoralNet versions serve as landmarks to improve communication between devs about new changes and associated upgrade steps. These landmarks can also help with troubleshooting issues.
 
 Versions take on the form A.B.C, where:
 
@@ -18,15 +20,9 @@ Versions take on the form A.B.C, where:
 
   Patch versions can be used as often or as scarcely as we see fit; we may frequently have smaller PRs which don't have any version bump at all.
 
-Note that the versioning system for pluggable apps tends to be different; in particular, the criteria for B is usually considered worthy of a major version. But the system above feels better optimized for CoralNet; this is an end-user app, not a pluggable one.
+Note that the versioning system for pluggable apps tends to be different; in particular, the criteria for B are often considered worthy of a major version. But the system above feels better optimized for CoralNet; this is an end-user app, not a pluggable one.
 
-When it's time to bump the version, we should:
-
-1. Add a Git tag to the appropriate point in the commit history. Note that tags can be pushed and fetched along with everything else in the repo. ``git push --follow-tags`` to include tags in your push, or ``git push origin <tag_name>`` to push only a single tag.
-
-2. Add an entry to the top of the ``CHANGELOG.md`` file. At minimum, this should include update-instructions for major and minor versions (e.g. "New migrations in vision_backend"). Would also be nice to have a brief description of the changes in functionality.
-
-Then, a dev looking to update an environment can:
+A dev looking to update an environment can:
 
 1. Identify the version their environment is on, and the version they want to update to.
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,11 +7,8 @@
 # Django project.
 coverage
 
-# Documentation.
-# The version shouldn't really matter here, as it's not part of the running
-# Django project.
-Sphinx
+# reStructuredText documentation.
+Sphinx>=5.0
 
-
-# For development. This allows pre-commit hooks for syntax linting.
+# Allows pre-commit hooks for syntax linting.
 pre-commit==2.10.1


### PR DESCRIPTION
Most notably the 2nd commit: "Move docs' release steps to coralnet-system. Link semantic versioning docs from CHANGELOG.md."